### PR TITLE
Add a script to review and merge Semgrep onboarding PRs, README for usage guidance

### DIFF
--- a/semgrep-ci/github/README.md
+++ b/semgrep-ci/github/README.md
@@ -2,7 +2,7 @@
 
 If you use branch protection on your GitHub repos, onboarding Semgrep to many repos at the same time is not currently possible through the Semgrep Cloud Platform UI. The scripts in this directory provide an alternative. The script `onboard-repos.sh` creates PRs for all targeted repos in an organization, and the script `approve-semgrep-prs.sh` approves and merges those PRs.
 
-The approval script is optional. PRs can also be merged manually. If you run the approval script, you can also choose whether or not to merge the approved PR.
+The approval script is optional. PRs can also be reviewed manually. If you run the approval script, you can also choose whether or not to merge the approved PR.
 
 To easily provide a secure `SEMGREP_APP_TOKEN` value to all repos, set the value as an [organization secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-organization). If you do not have access to organization secrets, consider setting up a [reusable workflow](https://semgrep.dev/docs/kb/semgrep-ci/github-reusable-workflows-semgrep/) and referencing that workflow in the `semgrep.yml` you will use to onboard other repositories.
 
@@ -15,7 +15,7 @@ After installing the client, determine which GitHub account to log in with.
 * To create PRs, you need a GitHub user account that has permission to create PRs on any repos in the target organization that you want to onboard.
 * To approve and merge PRs, you need a **different** user account that has permission to review and merge PRs on those same repos. The same user cannot both create and review a PR.
 
-Use `gh auth login` to log in. To change users, use `gh auth logout` and then log in with the new user. Use `gh auth login --help` to see more options (e.g. for GitHub enterprise, or to use a token).
+Use `gh auth login` to log in. To change users, use `gh auth logout` and then log in with the new user. Use `gh auth login --help` to see more options (e.g. for GitHub Enterprise Server, or to use a token).
 
 ## How the scripts work
 
@@ -27,7 +27,7 @@ Use `gh auth login` to log in. To change users, use `gh auth logout` and then lo
   * Approves PRs for all repos in an organization up to a configurable limit.
   * Merges PRs if `-m` flag is set.
 
-The onboarding script will catch errors in branch and commit creation, and print messages as to whether the error is concerning. Some errors are expected - for example, if you already have a branch of a particular name, and the script tries to create a branch with the same name, it records that the branch exists and proceeds. (Using a relatively unique branch name is recommended. The default is `add-semgrep`.)
+The onboarding script will catch errors during the branch and commit creation process, and print messages as to whether the error is concerning. Some errors are expected: for example, if you already have a branch of a particular name, and the script tries to create a branch with the same name, it records that the branch exists and proceeds. (Using a relatively unique branch name is recommended. The default is `add-semgrep`.)
 
 If unexpected errors occur when creating the branch and adding the file, onboarding for that repo will be skipped and the script will proceed to the next repo.
 

--- a/semgrep-ci/github/README.md
+++ b/semgrep-ci/github/README.md
@@ -25,6 +25,7 @@ Use `gh auth login` to log in. To change users, use `gh auth logout` and then lo
   * PR title and content can be modified through the script body.
 * `approve-semgrep-prs.sh`: Approves and merges PRs from the provided branch name. This branch name should match the one used in `onboard-repos.sh`.
   * Approves PRs for all repos in an organization up to a configurable limit.
+  * Merges PRs if `-m` flag is set.
 
 The onboarding script will catch errors in branch and commit creation, and print messages as to whether the error is concerning. Some errors are expected - for example, if you already have a branch of a particular name, and the script tries to create a branch with the same name, it records that the branch exists and proceeds. (Using a relatively unique branch name is recommended. The default is `add-semgrep`.)
 

--- a/semgrep-ci/github/README.md
+++ b/semgrep-ci/github/README.md
@@ -1,0 +1,43 @@
+# Creating (and approving) PRs to onboard Semgrep to GitHub repos
+
+If you use branch protection on your GitHub repos, onboarding Semgrep to many repos at the same time is not currently possible through the Semgrep Cloud Platform UI. The scripts in this directory provide an alternative. The script `onboard-repos.sh` creates PRs for all targeted repos in an organization, and the script `approve-semgrep-prs.sh` approves and merges those PRs.
+
+The approval script is optional. PRs can also be merged manually. If you run the approval script, you can also choose whether or not to merge the approved PR.
+
+To easily provide a secure `SEMGREP_APP_TOKEN` value to all repos, set the value as an [organization secret](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-organization). If you do not have access to organization secrets, consider setting up a [reusable workflow](https://semgrep.dev/docs/kb/semgrep-ci/github-reusable-workflows-semgrep/) and referencing that workflow in the `semgrep.yml` you will use to onboard other repositories.
+
+## Prerequisities
+
+The scripts make use of the [`gh`](https://cli.github.com/manual/gh) command line client to interact with the GitHub API. Install the client before attempting to use the script. For Mac, the client is available via `brew`.
+
+After installing the client, determine which GitHub account to log in with.
+
+* To create PRs, you need a GitHub user account that has permission to create PRs on any repos in the target organization that you want to onboard.
+* To approve and merge PRs, you need a **different** user account that has permission to review and merge PRs on those same repos. The same user cannot both create and review a PR.
+
+Use `gh auth login` to log in. To change users, use `gh auth logout` and then log in with the new user. Use `gh auth login --help` to see more options (e.g. for GitHub enterprise, or to use a token).
+
+## How the scripts work
+
+* `onboard-repos.sh`: Requires a local `semgrep.yml` specifying the desired configuration. Checks repos for existing Semgrep workflow files. Repos with existing files are skipped. Other repos have PRs opened on a new branch with the content of the local `semgrep.yml`.
+  * Onboards all repos in an organization up to a configurable limit.
+  * Branch name for PRs is configurable.
+  * PR title and content can be modified through the script body.
+* `approve-semgrep-prs.sh`: Approves and merges PRs from the provided branch name. This branch name should match the one used in `onboard-repos.sh`.
+  * Approves PRs for all repos in an organization up to a configurable limit.
+
+The onboarding script will catch errors in branch and commit creation, and print messages as to whether the error is concerning. Some errors are expected - for example, if you already have a branch of a particular name, and the script tries to create a branch with the same name, it records that the branch exists and proceeds. (Using a relatively unique branch name is recommended. The default is `add-semgrep`.)
+
+If unexpected errors occur when creating the branch and adding the file, onboarding for that repo will be skipped and the script will proceed to the next repo.
+
+If errors occur in creating, reviewing, or merging the PR, the script will print the error that occurred. Most errors for these commands provide helpful guidance to resolve the issue. For example, if the same user attempts to review the PR who created it, you see `failed to create review: GraphQL: Can not approve your own pull request (addPullRequestReview)`.
+
+## Sample workflow
+
+1. Download scripts to a local directory.
+2. Create `semgrep.yml` in local directory, according to your needs. See [Sample GitHub Actions configuration file](https://semgrep.dev/docs/semgrep-ci/sample-ci-configs/#sample-github-actions-configuration-file) and [CI environment variables](https://semgrep.dev/docs/semgrep-ci/ci-environment-variables/) in the Semgrep docs.
+3. `brew install gh`
+4. `gh auth login` and log in as the user who will create all the PRs.
+5. Execute `onboard-repos.sh -o YOUR_GITHUB_ORG`. If you wish to test with a small number of repos first, set a low limit, such as `-l 5`.
+6. If PR creation is generally successful, proceed with `gh auth logout` and then `gh auth login` as the user who will approve and merge the PRs.
+7. Run `approve-semgrep-prs.sh` to approve the PRs. Run with `-m` to merge the PRs.

--- a/semgrep-ci/github/approve-semgrep-prs.sh
+++ b/semgrep-ci/github/approve-semgrep-prs.sh
@@ -42,6 +42,7 @@ gh repo list $GH_ORG_NAME --no-archived -L $REPO_LIMIT --json name > repos.json
 echo "Collecting repo names..."
 GITHUB_REPOS=($(jq -r '.[].name' repos.json))
 
+# Iterate over repo PRs, approving (and potentially merging) each one
 for i in ${!GITHUB_REPOS[@]}; do
   GH_REPO_NAME=${GITHUB_REPOS[$i]}
   gh pr review -R "$GH_ORG_NAME/$GH_REPO_NAME" $BRANCH_NAME --approve

--- a/semgrep-ci/github/approve-semgrep-prs.sh
+++ b/semgrep-ci/github/approve-semgrep-prs.sh
@@ -13,7 +13,7 @@ done
 
 if [[ -z $GH_ORG_NAME ]]
 then
-  echo "Usage: $0 -o github_org_name [-b branch_name] [-l repo_limit]"
+  echo "Usage: $0 -o github_org_name [-b branch_name] [-l repo_limit] [-m]"
   exit 1
 fi
 

--- a/semgrep-ci/github/approve-semgrep-prs.sh
+++ b/semgrep-ci/github/approve-semgrep-prs.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Check for org and branch names and repo limit
+while getopts o:b:l:m flag
+do
+  case $flag in
+    o) GH_ORG_NAME=${OPTARG};;
+    b) BRANCH_NAME=${OPTARG};;
+    l) REPO_LIMIT=${OPTARG};;
+    m) MERGE=true;;
+  esac
+done
+
+if [[ -z $GH_ORG_NAME ]]
+then
+  echo "Usage: $0 -o github_org_name [-b branch_name] [-l repo_limit]"
+  exit 1
+fi
+
+# If optional variables are not set, fall back to default
+if [[ -z $BRANCH_NAME ]]
+then
+  BRANCH_NAME="add-semgrep"
+fi
+
+if [[ -z $REPO_LIMIT ]]
+then
+  REPO_LIMIT=10
+fi
+
+echo "This script uses the Github CLI (gh) client to approve existing PRs
+      on $BRANCH_NAME to add semgrep to repos in $GH_ORG_NAME."
+
+if [[ -n $MERGE ]]
+then
+  echo "The PRs will also be merged."
+fi
+
+
+# Grab only the repo name of unarchived repos with limit $REPO_LIMIT
+gh repo list $GH_ORG_NAME --no-archived -L $REPO_LIMIT --json name > repos.json
+echo "Collecting repo names..."
+GITHUB_REPOS=($(jq -r '.[].name' repos.json))
+
+for i in ${!GITHUB_REPOS[@]}; do
+  GH_REPO_NAME=${GITHUB_REPOS[$i]}
+  gh pr review -R "$GH_ORG_NAME/$GH_REPO_NAME" $BRANCH_NAME --approve
+  if [[ $MERGE == true ]]
+  then
+    gh pr merge -R "$GH_ORG_NAME/$GH_REPO_NAME" $BRANCH_NAME -m
+  fi
+done
+
+# Cleanup
+rm -f repos.json

--- a/semgrep-ci/github/onboard-repos.sh
+++ b/semgrep-ci/github/onboard-repos.sh
@@ -1,37 +1,49 @@
 #!/bin/bash
 
-# TODO: Work out a way to change the cron per-repo (probably not critical but wd be better)
-# Where does the secret come from? Maybe we should do the reusable workflows?
+# TODO: Work out a way to change the cron per-repo (not critical but would be better)
+# Set secret at org level
 
+# A local semgrep.yml is required
 if ! [[ -f semgrep.yml ]]
 then
   echo "Please create a semgrep.yml in the current directory to add to every repo."
   exit 1
 fi
 
-while getopts ao: flag
+# Check for org and branch names and repo limit
+while getopts o:b:l: flag
 do
   case $flag in
     o) GH_ORG_NAME=${OPTARG};;
-    a) APPROVE=true;;
+    b) BRANCH_NAME=${OPTARG};;
+    l) REPO_LIMIT=${OPTARG};;
   esac
 done
 
+# Org name is required - we can't know it in advance
 if [[ -z $GH_ORG_NAME ]]
 then
-  echo "You must set an org name"
+  echo "Usage: $0 -o github_org_name [-b branch_name] [-l repo_limit]"
   exit 1
 fi
 
-# Set up variables
+# If optional variables are not set, fall back to default
+if [[ -z $BRANCH_NAME ]]
+then
+  BRANCH_NAME="add-semgrep"
+fi
+
+if [[ -z $REPO_LIMIT ]]
+then
+  REPO_LIMIT=10
+fi
+
+# These values can be safely modified, but are not configurable by default
 PR_TITLE="Add semgrep.yml to .github/workflows to run Semgrep scans"
 PR_BODY="Adding Semgrep GitHub action to scan code for security issues"
-# Change this limit to match the number of repos you want to onboard
-REPO_LIMIT=200
-BRANCH_NAME="add-semgrep"
 SEMGREP_YML_BASE64=$(cat semgrep.yml | base64)
 
-echo "This script uses the Github CLI (gh) client to add semgrep to repos in $GH_ORG_NAME 
+echo "This script uses the Github CLI (gh) client to add semgrep to repos in $GH_ORG_NAME
 by creating PRs on branch $BRANCH_NAME."
 
 if [[ -z $APPROVE ]]
@@ -42,39 +54,39 @@ else
 fi
 
 # Grab only the repo name and default branch of unarchived repos with limit $REPO_LIMIT
-gh repo list $GH_ORG_NAME --no-archived -L $REPO_LIMIT --json nameWithOwner,defaultBranchRef > repos.json
+gh repo list $GH_ORG_NAME --no-archived -L $REPO_LIMIT --json name,defaultBranchRef > repos.json
 echo "Collecting repo names and default branches..."
-GITHUB_REPOS=($(jq -r '.[].nameWithOwner' repos.json))
+GITHUB_REPOS=($(jq -r '.[].name' repos.json))
 GITHUB_BRANCHES=($(jq -r '.[].defaultBranchRef.name' repos.json))
 
 # iterate over repos, creating PRs for each one
 for i in ${!GITHUB_REPOS[@]}; do
-  GH_REPO=${GITHUB_REPOS[$i]}
+  GH_REPO_NAME=${GITHUB_REPOS[$i]}
   GH_DEFAULT_BRANCH=${GITHUB_BRANCHES[$i]}
   # Check if the file exists on the default branch
-  SEMGREP_ONBOARDED=`gh api repos/{owner}/{repo}/contents/.github/workflows/semgrep.yml\?branch=$GH_DEFAULT_BRANCH --jq '.name'`
+  SEMGREP_ONBOARDED=`gh api repos/$GH_ORG_NAME/$GH_REPO_NAME/contents/.github/workflows/semgrep.yml\?branch=$GH_DEFAULT_BRANCH --jq '.name'`
   if [[ $SEMGREP_ONBOARDED == 'semgrep.yml' ]]
   then
-    echo "Semgrep already onboarded for $GH_REPO. Moving to next repo."
+    echo "Semgrep already onboarded for $GH_REPO_NAME. Moving to next repo."
     continue
   fi
-  echo "Creating $BRANCH_NAME on $GH_REPO based on $GH_DEFAULT_BRANCH"
+  echo "Creating $BRANCH_NAME on $GH_REPO_NAME based on $GH_DEFAULT_BRANCH"
   # Get the SHA of the default branch
-  DEFAULT_BRANCH_SHA=$(gh api repos/{owner}/{repo}/git/ref/heads/$GH_DEFAULT_BRANCH --jq ".object.sha")
+  DEFAULT_BRANCH_SHA=$(gh api repos/$GH_ORG_NAME/$GH_REPO_NAME/git/ref/heads/$GH_DEFAULT_BRANCH --jq ".object.sha")
   # Create the new branch off the default branch sha
-  BRANCH_CREATION_RESULT=`gh api repos/{owner}/{repo}/git/refs -X POST -F ref=refs/heads/$BRANCH_NAME -F sha=$DEFAULT_BRANCH_SHA`
+  BRANCH_CREATION_RESULT=`gh api repos/$GH_ORG_NAME/$GH_REPO_NAME/git/refs -X POST -F ref=refs/heads/$BRANCH_NAME -F sha=$DEFAULT_BRANCH_SHA`
   BC_STATUS=$?
   if [[ $BRANCH_CREATION_RESULT =~ "Reference already exists" ]]
   then
-    echo "A branch with the name $BRANCH_NAME already exists on $GH_REPO, no need to create one."
+    echo "A branch with the name $BRANCH_NAME already exists on $GH_REPO_NAME, no need to create one."
   elif [[ $BC_STATUS -ne 0 ]]
   then
-    echo "Something else went wrong for $GH_REPO: $BRANCH_CREATION_RESULT"
-    continue    
+    echo "Something else went wrong for $GH_REPO_NAME: $BRANCH_CREATION_RESULT"
+    continue
   fi
   # Add the file to the branch (creates a commit also)
-  echo "Creating semgrep.yml on $BRANCH_NAME in $GH_REPO"
-  FILE_CREATION_RESULT=`gh api repos/{owner}/{repo}/contents/.github/workflows/semgrep.yml \
+  echo "Creating semgrep.yml on $BRANCH_NAME in $GH_REPO_NAME"
+  FILE_CREATION_RESULT=`gh api repos/$GH_ORG_NAME/$GH_REPO_NAME/contents/.github/workflows/semgrep.yml \
     -X PUT \
     -H "Accept: application/vnd.github.v3+json" \
     -F message="Add semgrep.yml" \
@@ -84,16 +96,16 @@ for i in ${!GITHUB_REPOS[@]}; do
   # If the file exists, GitHub expects a sha to update it from, so "sha wasn't supplied" means the file exists (weird but true)
   if [[ $FILE_CREATION_RESULT =~ "\\\"sha\\\" wasn't supplied" ]]
   then
-    echo "A semgrep.yml file already exists on $BRANCH_NAME in $GH_REPO, no need to create one."
+    echo "A semgrep.yml file already exists on $BRANCH_NAME in $GH_REPO_NAME, no need to create one."
   elif [[ $FC_STATUS -ne 0 ]]
   then
-    echo "Something else went wrong for $GH_REPO: $FILE_CREATION_RESULT"
-    continue    
+    echo "Something else went wrong for $GH_REPO_NAME: $FILE_CREATION_RESULT"
+    continue
   fi
   # Create a PR with the branch and added file
-  echo "Creating PR for $BRANCH_NAME in $GH_REPO to $GH_DEFAULT_BRANCH"
-  gh pr create -b "$PR_BODY" -R $GH_REPO -t "$PR_TITLE" --base $GH_DEFAULT_BRANCH -H $BRANCH_NAME
-  
-  # Cleanup
-  rm -f repos.json
+  echo "Creating PR for $BRANCH_NAME in $GH_REPO_NAME to $GH_DEFAULT_BRANCH"
+  gh pr create -b "$PR_BODY" -R "$GH_ORG_NAME/$GH_REPO_NAME" -t "$PR_TITLE" --base $GH_DEFAULT_BRANCH -H $BRANCH_NAME
 done
+
+# Cleanup
+rm -f repos.json

--- a/semgrep-ci/github/onboard-repos.sh
+++ b/semgrep-ci/github/onboard-repos.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # TODO: Work out a way to change the cron per-repo (not critical but would be better)
-# Set secret at org level
 
 # A local semgrep.yml is required
 if ! [[ -f semgrep.yml ]]
@@ -45,13 +44,6 @@ SEMGREP_YML_BASE64=$(cat semgrep.yml | base64)
 
 echo "This script uses the Github CLI (gh) client to add semgrep to repos in $GH_ORG_NAME
 by creating PRs on branch $BRANCH_NAME."
-
-if [[ -z $APPROVE ]]
-then
-  echo "PRs will only be created, not approved."
-else
-  echo "PRs will be approved as well as created"
-fi
 
 # Grab only the repo name and default branch of unarchived repos with limit $REPO_LIMIT
 gh repo list $GH_ORG_NAME --no-archived -L $REPO_LIMIT --json name,defaultBranchRef > repos.json


### PR DESCRIPTION
@sinat101 pointed out when reviewing my initial onboarding script that the `gh` client also supports reviewing and approving PRs - so in theory, the whole process could be automated.

I had hoped to add this to the original script, but you need a different GH user to review in order for a review to be valid. I didn't have a lot of luck with my initial attempt to incorporate `gh auth login` into the script flow, so I opted to make separate scripts and provide a usage guide (README) that covers that issue & other usage information.

I also improved the original script to take command-line flags and provide better guidance and defaults if something is missing. For some reason I found that the `{owner}/{repo}` placeholders were not working as well, so I switched to just using variables there.