### PR TITLE
Update identifier URL and links section with all references

### DIFF
--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -7,11 +7,8 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
     with open(report_semgrep, 'r') as file_semgrep:
         data_semgrep = json.load(file_semgrep)
         for vuln in data_semgrep['results']:
-            
-            links = []
-            for ref in vuln.get('extra').get('metadata')['references']:
-                link = {"url": ref}
-                links.append(link)
+
+            links = [{"url": ref} for ref in vuln.get('extra').get('metadata')['references']]
 
             new_vuln = {
                         "id": vuln.get('extra')['fingerprint'][0:63],

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -7,6 +7,12 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
     with open(report_semgrep, 'r') as file_semgrep:
         data_semgrep = json.load(file_semgrep)
         for vuln in data_semgrep['results']:
+            
+            links = []
+            for ref in vuln.get('extra').get('metadata')['references']:
+                link = {"url": ref}
+                links.append(link)
+
             new_vuln = {
                         "id": vuln.get('extra')['fingerprint'][0:63],
                         "name": "Semgrep: " + vuln['check_id'],
@@ -28,14 +34,10 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
                                 "type": "cve",
                                 "name": vuln.get('extra').get('metadata')['sca-vuln-database-identifier'],
                                 "value": vuln.get('extra').get('metadata')['sca-vuln-database-identifier'],
-                                "url": vuln.get('extra').get('metadata')['references'][0]
+                                "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name="+vuln.get('extra').get('metadata')['sca-vuln-database-identifier']
                             }
                         ],
-                        "links": [
-                            {
-                            "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name="+vuln.get('extra').get('metadata')['sca-vuln-database-identifier']
-                            }
-                        ],
+                        "links": links,
                         "details": {
                             "vulnerable_package": {
                             "type": "text",


### PR DESCRIPTION
The identifier (aka CVE ID) URL was previously being set to the first link in the references array. However since it is specifically the CVE, it should always be set to the MITRE CVE URL.

Additionally, the links array only had the MITRE CVE URL. Now, the links array has all the references available from the original JSON references array.