### PR TITLE
GitLab Vulnerability Dashboard requires unique ID for each scan type

### DIFF
--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -95,7 +95,7 @@ def get_new_scan_info(data):
     formatted_datetime = current_datetime.strftime("%Y-%m-%dT%H:%M:%S")
     new_scan_info = {
         "analyzer": {
-        "id": "semgrep",
+        "id": "semgrep_dep_scan",
         "name": "Semgrep",
         "url": "https://semgrep.dev",
         "vendor": {
@@ -104,7 +104,7 @@ def get_new_scan_info(data):
         "version": data['version']
         },
         "scanner": {
-        "id": "semgrep",
+        "id": "semgrep_dep_scan",
         "name": "Semgrep",
         "url": "https://semgrep.dev",
         "vendor": {


### PR DESCRIPTION
Sina, please check...

GitLab Vulnerability Dashboard requires unique ID for distinctive scan types. Otherwise Semgrep SAST and Semprep Supply Chain get mixed in the same bucket in non-deterministic way in GitLab Vulnerability Dashboard and drop down filter is corrupted.    

Before Fix 1:  
![before-fix2](https://github.com/r2c-CSE/semgrep-utilities/assets/3286033/49a52f23-a641-479b-9c99-a12d08586045)

Before Fix 2:    
![before-fix1](https://github.com/r2c-CSE/semgrep-utilities/assets/3286033/3654ff2a-1699-4afa-ba6d-d8be6e974278)

After Fix:  
![after-fix](https://github.com/r2c-CSE/semgrep-utilities/assets/3286033/9b4b6edd-7526-4e5a-8843-0b2d3d574756)
