### PR TITLE
Add line numbers to SCA script

### DIFF
--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -19,6 +19,8 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
                         "solution": "Upgrade dependencies to fixed versions: "+get_solution(vuln), 
                         "location": {
                             "file": vuln.get('extra').get('sca_info').get('dependency_match')['lockfile'],
+                            "start_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['line_number'],
+                            "end_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['line_number'],
                             "dependency": {
                             "package": {
                                 "name": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['package']

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -14,7 +14,6 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
                         "id": vuln.get('extra')['fingerprint'][0:63],
                         "name": "Semgrep: " + vuln['check_id'],
                         "description": vuln.get('extra')['message'],
-                        #"cve": vuln.get('extra').get('metadata')['sca-vuln-database-identifier'],
                         "severity": get_severity(vuln),
                         "solution": "Upgrade dependencies to fixed versions: "+get_solution(vuln), 
                         "location": {

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -26,7 +26,6 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
                                     "name": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['package']
                                 },
                                 "version": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['version']
-                                }
                             }
                         },
                         "identifiers": [
@@ -46,7 +45,6 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
                             + ":" + vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['version'] 
                         }
                     }
-                        
             }
             data['vulnerabilities'].append(new_vuln)
 

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -14,19 +14,19 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
                         "id": vuln.get('extra')['fingerprint'][0:63],
                         "name": "Semgrep: " + vuln['check_id'],
                         "description": vuln.get('extra')['message'],
-                        "cve": vuln.get('extra').get('metadata')['sca-vuln-database-identifier'],
+                        #"cve": vuln.get('extra').get('metadata')['sca-vuln-database-identifier'],
                         "severity": get_severity(vuln),
                         "solution": "Upgrade dependencies to fixed versions: "+get_solution(vuln), 
                         "location": {
                             "file": vuln.get('extra').get('sca_info').get('dependency_match')['lockfile'],
                             "start_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['line_number'],
                             "end_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['line_number'],
-                            "dependency": {
-                            "package": {
-                                "name": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['package']
-                            },
-                            "version": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['version']
-                            }
+                        #    "dependency": {
+                        #    "package": {
+                        #        "name": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['package']
+                        #    },
+                        #    "version": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['version']
+                        #    }
                         },
                         "identifiers": [
                             {

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -21,12 +21,13 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
                             "file": vuln.get('extra').get('sca_info').get('dependency_match')['lockfile'],
                             "start_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['line_number'],
                             "end_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['line_number'],
-                        #    "dependency": {
-                        #    "package": {
-                        #        "name": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['package']
-                        #    },
-                        #    "version": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['version']
-                        #    }
+                            "dependency": {
+                                "package": {
+                                    "name": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['package']
+                                },
+                                "version": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['version']
+                                }
+                            }
                         },
                         "identifiers": [
                             {


### PR DESCRIPTION
GitLab allows/expects the line numbers to be included, and they're available in the original JSON, so let's include them.

Tested on r2cse GLSM instance, with this result:
![image](https://github.com/r2c-CSE/semgrep-utilities/assets/1274037/7599915e-6a22-4857-8911-57eb74b6f884)

You can see the line number is present now under Location, which $CUSTOMER reported it previously wasn't.