### PR TITLE
Defensively get line number to avoid errors if not present

### DIFF
--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -18,8 +18,8 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
                         "solution": "Upgrade dependencies to fixed versions: "+get_solution(vuln), 
                         "location": {
                             "file": vuln.get('extra').get('sca_info').get('dependency_match')['lockfile'],
-                            "start_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['line_number'],
-                            "end_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['line_number'],
+                            "start_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency').get('line_number'),
+                            "end_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency').get('line_number'),
                             "dependency": {
                                 "package": {
                                     "name": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['package']


### PR DESCRIPTION
I was a bit lazy in the first fix and assumed that line number was always present even if it might be non-meaningful (e.g. 0). However, we just don't provide lines for Cargo.lock files at all (due to the [fairly basic way](https://github.com/semgrep/semgrep/blob/084d952d018a0c058e252e637899841217a524c5/cli/src/semdep/parse_lockfile.py#L42) we currently parse them), so we need to use `.get` here as well.