### PR TITLE
Refactor python client and add project pagination

### DIFF
--- a/utilities/api/python_client_semgrep_api.py
+++ b/utilities/api/python_client_semgrep_api.py
@@ -59,7 +59,7 @@ def get_projects(deployment_slug, headers):
     
 def get_all_findings(projects, headers):
     """
-    Gets all findings for all project, and writes each to a separate file.
+    Gets all findings for all projects.
     """
     for project in projects['projects']:
         project_name = project['name']
@@ -68,6 +68,10 @@ def get_all_findings(projects, headers):
     
 
 def get_findings_per_project(deployment_slug, project, headers):
+    """
+    Gets all findings for a project, and writes them to a file.
+    The file format is equivalent to what the API would return if it weren't paginated.
+    """
     project_findings = retrieve_paginated_data(f"{BASE_URL}/{deployment_slug}/findings?repos={project}&dedup=false", "findings", 3000, headers=headers)
     file_path = re.sub(r"[^\w\s]", "-", project) + ".json"
     with open(file_path, "w") as file:


### PR DESCRIPTION
I was only planning on adding pagination to the project call at a customer request, but I was having a hard time finding a tidy way to do that given how the functions were written. So ... I decided to refactor the whole thing so that pagination is in a common utility, and functions do what they say they do (so get all projects only gets projects, not findings). As a bonus, repetition is significantly reduced via use of arguments, and some unnecessary calls removed.

The script should pretty much work in the same way aside from paginating the projects, and one other small change - I had it replace nonword characters in project names with `-` instead of nothing, which to me makes the file names easier to manage. I can revert this change if it's not desirable, though.