### PR TITLE
Handle missing references in SAST-findings-to-gitlab script

### DIFF
--- a/integrations/gitlab/sastGitLabScript.py
+++ b/integrations/gitlab/sastGitLabScript.py
@@ -11,7 +11,8 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
         for vuln in data_semgrep['results']:
             if not vuln['check_id'].startswith('ssc-'):
 
-                links = [{"url": ref} for ref in vuln.get('extra').get('metadata')['references']]
+                # Most rules have reference links but not all
+                links = [{"url": ref} for ref in vuln.get('extra').get('metadata').get('references', [])]
                 rule_name = vuln['check_id']
                 rule_name = rule_name[rule_name.rfind('.')+1:]
                 rule_name = rule_name.replace('-', ' ')


### PR DESCRIPTION
This broke on a customer findings file that included OSS rules without reference links, let's handle that case. Tested this on the example given in the ticket and also on a set of [govwa findings](https://github.com/r2c-CSE/govwa) with a reference block deleted.