### PR TITLE
Revise "evicted" regex

### DIFF
--- a/scala/build.sbt
+++ b/scala/build.sbt
@@ -20,8 +20,10 @@ dependencyTreeTransform := {
   line.replace("[info]", "").replace("[S]", "").trim
 }.filterNot { line =>
   line.matches("^[ |]+$") || line.isEmpty
+  // This regex is short and simple because "evicted" is sometimes truncated
+  // When revising, recommended to check behavior and performance with a regex tester
 }.filterNot{ line => 
-  line.matches(".+evicted by: .+")
+  line.matches("\(evi.+")
 }.map { line =>
   val parts = line.split(':')
   val formattedLine = if (parts.length > 2) {

--- a/scala/transform.py
+++ b/scala/transform.py
@@ -34,7 +34,9 @@ def transform_lines_with_space(original):
         if re.match('^[ |]+$', line) or line == "":
             continue
         # Skip "evicted" dependencies as they are superseded by a different version
-        if re.match('.+evicted by: .+', line):
+        # This regex is short and simple because "evicted" is sometimes truncated
+        # When revising, recommended to check behavior and performance with a regex tester
+        if re.match(r'\(evi.+', line):
             continue
         parts = line.split(':')
         if len(parts) > 2:


### PR DESCRIPTION
When the initial dependency tree job runs, the file that is generated has some "evicted" dependency versions, and these are not used, so they should be removed in the final result.

However, our regex was too specific - it relied on the lines not being truncated, and they are seemingly being truncated even in some cases where the line width has been set very wide.

The regex has been revised to be short and simple and still not show FN/FP on an example dependency tree. There is some risk that it could match unexpectedly in other cases, but keeping it simple improves performance, and further adjustments can be made later if necessary.