### PR TITLE
SCA GitLab script: do not automatically set Critical severity for Reachable vulnerabilities

### DIFF
--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -93,12 +93,8 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
 
 def get_severity(vuln):
     severity = to_hungarian_case(vuln.get('extra').get('metadata')['sca-severity'])
-    kind = vuln.get('extra').get('metadata')['sca-kind']
-    if kind == "reachable":
-        severity = "Critical"
-    else:
-        if severity == "Moderate":
-            severity = "Medium"
+    if severity == "Moderate":
+        severity = "Medium"
     return severity
 
 def get_exposure(vuln):


### PR DESCRIPTION
The SCA script for GitLab output currently uses the logic that if kind == reachable, the severity is set to Critical. However, this is not always desirable, so this PR removes that logic and the severity now remains unchanged by the reachability. 