### PR TITLE
fix: Return multiple versions from gitlab vulnerability report converter

### DIFF
--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -145,11 +145,12 @@ def get_solution(vuln):
     if not sca_fix_versions:
         return "No known fixed versions"
 
-    solution_string = ""
-    for sol in sca_fix_versions:
-        solution_string = str(sol)[1:-1].replace("'", "")
-    
-    return solution_string
+    solutions = []
+    for solution in sca_fix_versions:
+        for package, version in solution.items():
+            solutions.append(f"{package}:{version}")
+
+    return ", ".join(solutions)
 
 def get_new_scan_info(data):
     current_datetime = datetime.now()


### PR DESCRIPTION
Example for [CVE-2024-37890](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-37890):

Before: `"solution": "Upgrade dependencies to fixed versions: ws: 5.2.4"`
After: `"solution": "Upgrade dependencies to fixed versions: ws:8.17.1, ws:7.5.10, ws:6.2.3, ws:5.2.4"`