### PR TITLE
Group recommended patches

### DIFF
--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -23,7 +23,7 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
                             "name": package_name + " - " + cwe_title,
                             "description": vuln.get('extra')['message'],
                             "severity": get_severity(vuln),
-                            "solution": "Upgrade dependencies to fixed versions (grouped by package): "+get_solution(vuln), 
+                            "solution": "Upgrade dependencies to fixed versions: "+get_solution(vuln), 
                             "location": {
                                 "file": vuln.get('extra').get('sca_info').get('dependency_match')['lockfile'],
                                 "start_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency').get('line_number'),
@@ -161,7 +161,7 @@ def get_solution(vuln):
     for package, versions in solutions.items():
         # Sort the versions
         sorted_versions = sorted(versions)
-        formatted_solutions.append(f"{package}: {', '.join(sorted_versions).join(';')}")
+        formatted_solutions.append(f"{package}: {', '.join(sorted_versions)};")
 
     # Join the lines with newline for formatting
     return "\n".join(formatted_solutions)

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from datetime import datetime
+from collections import defaultdict
 
 def conversion_semgrep_to_gitlab(report_semgrep, data):
     print("Populating Supply Chain findings data from Semgrep JSON report")

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -165,7 +165,7 @@ def get_solution(vuln):
         formatted_solutions.append(f"<li>{package}: {', '.join(sorted_versions)};</li>")
 
     # Wrap the list items in an unordered list
-    return "<p>Upgrade dependencies to fixed versions:</p><ul>" + "\n".join(formatted_solutions) + "</ul>"
+    return "<ul>" + "\n".join(formatted_solutions) + "</ul>"
 
 def get_new_scan_info(data):
     current_datetime = datetime.now()

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -164,7 +164,7 @@ def get_solution(vuln):
         formatted_solutions.append(f"{package}: {', '.join(sorted_versions)}")
 
     # Join the lines with newline for formatting
-    return formatted_solutions
+    return "\n".join(formatted_solutions)
 
 def get_new_scan_info(data):
     current_datetime = datetime.now()

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -146,7 +146,7 @@ def get_solution(vuln):
     sca_fix_versions = vuln.get('extra').get('metadata').get('sca-fix-versions', [])
     
     if not sca_fix_versions:
-        return "No known fixed versions"
+        return "<p>No known fixed versions</p>"
 
     # Use defaultdict to group versions by package name
     solutions = defaultdict(list)
@@ -156,15 +156,16 @@ def get_solution(vuln):
         for package, version in solution.items():
             solutions[package].append(version)
     
-    # Sort the versions for each package and format the output
+    # Sort the versions for each package and format the output as HTML list items
     formatted_solutions = []
     for package, versions in solutions.items():
         # Sort the versions
         sorted_versions = sorted(versions)
-        formatted_solutions.append(f"{package}: {', '.join(sorted_versions)};")
+        # Append the package and sorted versions as a list item with a semicolon
+        formatted_solutions.append(f"<li>{package}: {', '.join(sorted_versions)};</li>")
 
-    # Join the lines with newline for formatting
-    return "\n".join(formatted_solutions)
+    # Wrap the list items in an unordered list
+    return "<p>Upgrade dependencies to fixed versions:</p><ul>" + "\n".join(formatted_solutions) + "</ul>"
 
 def get_new_scan_info(data):
     current_datetime = datetime.now()

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -147,12 +147,23 @@ def get_solution(vuln):
     if not sca_fix_versions:
         return "No known fixed versions"
 
-    solutions = []
+    # Use defaultdict to group versions by package name
+    solutions = defaultdict(list)
+    
+    # Group versions by package
     for solution in sca_fix_versions:
         for package, version in solution.items():
-            solutions.append(f"{package}:{version}")
+            solutions[package].append(version)
+    
+    # Sort the versions for each package and format the output
+    formatted_solutions = []
+    for package, versions in solutions.items():
+        # Sort the versions
+        sorted_versions = sorted(versions)
+        formatted_solutions.append(f"{package}: {', '.join(sorted_versions)}")
 
-    return ", ".join(solutions)
+    # Join the lines with newline for formatting
+    return formatted_solutions
 
 def get_new_scan_info(data):
     current_datetime = datetime.now()

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -23,7 +23,7 @@ def conversion_semgrep_to_gitlab(report_semgrep, data):
                             "name": package_name + " - " + cwe_title,
                             "description": vuln.get('extra')['message'],
                             "severity": get_severity(vuln),
-                            "solution": "Upgrade dependencies to fixed versions: "+get_solution(vuln), 
+                            "solution": "Upgrade dependencies to fixed versions (grouped by package): "+get_solution(vuln), 
                             "location": {
                                 "file": vuln.get('extra').get('sca_info').get('dependency_match')['lockfile'],
                                 "start_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency').get('line_number'),
@@ -161,7 +161,7 @@ def get_solution(vuln):
     for package, versions in solutions.items():
         # Sort the versions
         sorted_versions = sorted(versions)
-        formatted_solutions.append(f"{package}: {', '.join(sorted_versions)}")
+        formatted_solutions.append(f"{package}: {', '.join(sorted_versions).join';'}")
 
     # Join the lines with newline for formatting
     return "\n".join(formatted_solutions)

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -161,7 +161,7 @@ def get_solution(vuln):
     for package, versions in solutions.items():
         # Sort the versions
         sorted_versions = sorted(versions)
-        formatted_solutions.append(f"{package}: {', '.join(sorted_versions).join';'}")
+        formatted_solutions.append(f"{package}: {', '.join(sorted_versions).join(';')}")
 
     # Join the lines with newline for formatting
     return "\n".join(formatted_solutions)

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -156,13 +156,11 @@ def get_solution(vuln):
         for package, version in solution.items():
             solutions[package].append(version)
     
-    # Sort the versions for each package and format the output as HTML list items
+    # Format the output as HTML list items
     formatted_solutions = []
     for package, versions in solutions.items():
-        # Sort the versions
-        sorted_versions = sorted(versions)
         # Append the package and sorted versions as a list item with a semicolon
-        formatted_solutions.append(f"<li>{package}: {', '.join(sorted_versions)};</li>")
+        formatted_solutions.append(f"<li>{package}: {', '.join(versions)};</li>")
 
     # Wrap the list items in an unordered list
     return "<ul>" + "\n".join(formatted_solutions) + "</ul>"


### PR DESCRIPTION
In the Gitlab report, there is a field **Solutions** with all the patches we could apply to fix an SSC issue.
We have improved the output by grouping the packages and sorting the versions.

The output looks like this before the change:
`Upgrade dependencies to fixed versions: org.springframework.boot:spring-boot-starter-web:2.6.6, org.springframework.boot:spring-boot-starter-web:2.5.12, org.springframework.boot:spring-boot-starter-webflux:2.6.6, org.springframework.boot:spring-boot-starter-webflux:2.5.12, org.springframework:spring-beans:5.3.18, org.springframework:spring-beans:5.2.20.RELEASE, org.springframework:spring-webflux:5.3.18, org.springframework:spring-webflux:5.2.20.RELEASE, org.springframework:spring-webmvc:5.3.18, org.springframework:spring-webmvc:5.2.20.RELEASE`

The output looks like this after the change: 
```
Upgrade dependencies to fixed versions: 

- org.springframework.boot:spring-boot-starter-web: 2.5.12, 2.6.6;
- org.springframework.boot:spring-boot-starter-webflux: 2.5.12, 2.6.6;
- org.springframework:spring-beans: 5.2.20.RELEASE, 5.3.18;
- org.springframework:spring-webflux: 5.2.20.RELEASE, 5.3.18;
- org.springframework:spring-webmvc: 5.2.20.RELEASE, 5.3.18;

```

I've included an example here to show the change.
<img width="893" alt="Screenshot 2024-09-20 at 14 02 42" src="https://github.com/user-attachments/assets/c9b07f20-19d8-4e4c-8ba6-f627a58c19a6">

