### PR TITLE
Unreachable lower severity

### DIFF
--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -103,7 +103,7 @@ def get_severity(vuln, lower_severity_unreachable):
     severity = to_hungarian_case(vuln.get('extra').get('metadata')['sca-severity'])
     if severity == "Moderate":
         severity = "Medium"
-    if low_severity_unreachable == "True":
+    if lower_severity_unreachable == "True":
         exposure = get_exposure(vuln)
         if exposure == "Unreachable":
             severity = "Info"

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -227,13 +227,14 @@ if __name__ == "__main__":
     else:
         print("Invalid file name. Your first argument must be a `*.json` file name.")
         sys.exit()
-        
+
+    lower_severity_unreachable = False
     for opt, arg in opts:
         if opt in ("-u", "--unreachable"):
             lower_severity_unreachable = str_to_bool(arg)
-        else:
-            lower_severity_unreachable = False
             
+    print("lower_severity_unreachable")
+    print(lower_severity_unreachable)
     print("Starting conversion process from Semgrep JSON to GitLab Dependency JSON")
     data = {
         "version": "15.0.0",

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -206,8 +206,6 @@ def to_hungarian_case(input_string):
     hungarian_case_words = input_string[0].upper() + input_string[1:].lower()
     return hungarian_case_words
 
-def str_to_bool(value):
-    return value.lower() in ("true", "1", "yes", "on")
 
 
 if __name__ == "__main__":

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime
 from collections import defaultdict
 
-def conversion_semgrep_to_gitlab(report_semgrep, data, lower_severity_unreachable):
+def conversion_semgrep_to_gitlab(report_semgrep, data, lowering_unreachable):
     print("Populating Supply Chain findings data from Semgrep JSON report")
     with open(report_semgrep, 'r') as file_semgrep:
         data_semgrep = json.load(file_semgrep)
@@ -25,7 +25,7 @@ def conversion_semgrep_to_gitlab(report_semgrep, data, lower_severity_unreachabl
                             "id": vuln.get('extra')['fingerprint'][0:63],
                             "name": package_name + " - " + cwe_title,
                             "description": vuln.get('extra')['message'],
-                            "severity": get_severity(vuln, lower_severity_unreachable),
+                            "severity": get_severity(vuln, lowering_unreachable),
                             "solution": "Upgrade dependencies to fixed versions: "+get_solution(vuln), 
                             "location": {
                                 "file": vuln.get('extra').get('sca_info').get('dependency_match')['lockfile'],
@@ -101,11 +101,11 @@ def conversion_semgrep_to_gitlab(report_semgrep, data, lower_severity_unreachabl
     with open('gl-dependency-scanning-report.json', 'w') as f:
         json.dump(data, f, indent=4)  # pretty print JSON
 
-def get_severity(vuln, lower_severity_unreachable):
+def get_severity(vuln, lowering_unreachable):
     severity = to_hungarian_case(vuln.get('extra').get('metadata')['sca-severity'])
     if severity == "Moderate":
         severity = "Medium"
-    if lower_severity_unreachable == True:
+    if lowering_unreachable == True:
         exposure = get_exposure(vuln)
         if exposure == "Unreachable":
             severity = "Info"
@@ -246,8 +246,8 @@ if __name__ == "__main__":
                 sys.exit(2)
 
             
-    print("lower_severity_unreachable")
-    print(lower_severity_unreachable)
+    print("lowering_unreachable")
+    print(lowering_unreachable)
     print("Starting conversion process from Semgrep JSON to GitLab Dependency JSON")
     data = {
         "version": "15.0.0",
@@ -256,4 +256,4 @@ if __name__ == "__main__":
         "scan": {}
     }
 
-    conversion_semgrep_to_gitlab(report_semgrep, data, lower_severity_unreachable)
+    conversion_semgrep_to_gitlab(report_semgrep, data, lowering_unreachable)

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -219,7 +219,9 @@ if __name__ == "__main__":
     try:
         # Define options: 'h' for help, 'l:' for the '--lowering-unreachable' which expects a value
         opts, args = getopt.getopt(user_inputs, "h", ["help", "lowering-unreachable="])
-
+        print("+++")
+        print(opts)
+        print(args)
         # The first non-option argument will be treated as the json_file
         if len(args) > 0:
             report_semgrep = args[0]
@@ -236,6 +238,7 @@ if __name__ == "__main__":
     for opt, arg in opts:
         print("+++")
         print(opt)
+        print(arg)
         if opt in ('-h', '--help'):
             print('Usage: scaGitLabScript.py <json_file> [--lowering-unreachable true|false]')
             sys.exit()

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -214,24 +214,37 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=logging.INFO)
     
-    user_inputs = sys.argv[1:]
-    # get option and value pair from getopt
+   lowering_unreachable = False  # Default to False unless explicitly set
+
     try:
-        opts, args = getopt.getopt(user_inputs, "lu", ["lowering-unreachable="])
-    except getopt.GetoptError:
-        logging.debug('pass the arguments like <Findings JSON file> --lowering-unreachable <true|false>')
+        # Define options: 'h' for help, 'l:' for the '--lowering-unreachable' which expects a value
+        opts, args = getopt.getopt(argv, "h", ["help", "lowering-unreachable="])
+
+        # The first non-option argument will be treated as the json_file
+        if len(args) > 0:
+            json_file = args[0]
+        else:
+            raise ValueError("No JSON file provided.")
+
+    except getopt.GetoptError as err:
+        print(str(err))
+        print('Usage: scaGitLabScript.py <json_file> [--lowering-unreachable true|false]')
         sys.exit(2)
 
-    if sys.argv[1].endswith('.json'):
-        report_semgrep = sys.argv[1]
-    else:
-        print("Invalid file name. Your first argument must be a `*.json` file name.")
-        sys.exit()
-
-    lower_severity_unreachable = False
+    # Parse options
     for opt, arg in opts:
-        if opt in ("--lowering-unreachable"):
-            lower_severity_unreachable = str_to_bool(arg)
+        if opt in ('-h', '--help'):
+            print('Usage: scaGitLabScript.py <json_file> [--lowering-unreachable true|false]')
+            sys.exit()
+        elif opt == '--lowering-unreachable':
+            if arg.lower() == 'true':
+                lowering_unreachable = True
+            elif arg.lower() == 'false':
+                lowering_unreachable = False
+            else:
+                print('Invalid value for --lowering-unreachable. Use true or false.')
+                sys.exit(2)
+
             
     print("lower_severity_unreachable")
     print(lower_severity_unreachable)

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -217,9 +217,9 @@ if __name__ == "__main__":
     user_inputs = sys.argv[1:]
     # get option and value pair from getopt
     try:
-        opts, args = getopt.getopt(user_inputs, "u", ["unreachable="])
+        opts, args = getopt.getopt(user_inputs, "lowering-unreachable")
     except getopt.GetoptError:
-        logging.debug('pass the arguments like <Findings JSON file> -u <true|false> or <Findings JSON file> --unreachable <true|false>')
+        logging.debug('pass the arguments like <Findings JSON file> --lowering-unreachable <true|false>')
         sys.exit(2)
 
     if sys.argv[1].endswith('.json'):
@@ -230,7 +230,7 @@ if __name__ == "__main__":
 
     lower_severity_unreachable = False
     for opt, arg in opts:
-        if opt in ("-u", "--unreachable"):
+        if opt in ("--lowering-unreachable"):
             lower_severity_unreachable = str_to_bool(arg)
             
     print("lower_severity_unreachable")

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+import getopt
 from datetime import datetime
 from collections import defaultdict
 
@@ -218,7 +219,7 @@ if __name__ == "__main__":
         logging.debug(opts)
         logging.debug(args)
     except getopt.GetoptError:
-        logging.debug('pass the arguments like -u <true|false> --unreachable <true|false>')
+        logging.debug('pass the arguments like <Findings JSON file> -u <true|false> or <Findings JSON file> --unreachable <true|false>')
         sys.exit(2)
 
     if sys.argv[1].endswith('.json'):

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -103,7 +103,7 @@ def get_severity(vuln, lower_severity_unreachable):
     severity = to_hungarian_case(vuln.get('extra').get('metadata')['sca-severity'])
     if severity == "Moderate":
         severity = "Medium"
-    if lower_severity_unreachable == "True":
+    if lower_severity_unreachable == True:
         exposure = get_exposure(vuln)
         if exposure == "Unreachable":
             severity = "Info"
@@ -204,22 +204,35 @@ def to_hungarian_case(input_string):
     hungarian_case_words = input_string[0].upper() + input_string[1:].lower()
     return hungarian_case_words
 
+def str_to_bool(value):
+    return value.lower() in ("true", "1", "yes", "on")
 
 
 if __name__ == "__main__":
 
-    if len(sys.argv) == 1:
-        print("A JSON file name argument must be provided.")
-        sys.exit()
+    user_inputs = sys.argv[1:]
+    # get option and value pair from getopt
+    try:
+        opts, args = getopt.getopt(user_inputs, "u", ["unreachable="])
+        #lets's check out how getopt parse the arguments
+        logging.debug(opts)
+        logging.debug(args)
+    except getopt.GetoptError:
+        logging.debug('pass the arguments like -u <true|false> --unreachable <true|false>')
+        sys.exit(2)
 
     if sys.argv[1].endswith('.json'):
         report_semgrep = sys.argv[1]
     else:
         print("Invalid file name. Your first argument must be a `*.json` file name.")
         sys.exit()
-
-    lower_severity_unreachable = os.getenv('LOWER_SEVERITY_UNREACHABLE', "False")
-
+        
+    for opt, arg in opts:
+        if opt in ("-u", "--unreachable"):
+            lower_severity_unreachable = str_to_bool(arg)
+        else:
+            lower_severity_unreachable = False
+            
     print("Starting conversion process from Semgrep JSON to GitLab Dependency JSON")
     data = {
         "version": "15.0.0",

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -102,6 +102,10 @@ def get_severity(vuln):
     severity = to_hungarian_case(vuln.get('extra').get('metadata')['sca-severity'])
     if severity == "Moderate":
         severity = "Medium"
+    if low_severity_unreachable == True:
+        exposure = get_exposure(vuln)
+        if exposure == "Unreachable":
+            severity = "Info"
     return severity
 
 def get_exposure(vuln):
@@ -212,6 +216,9 @@ if __name__ == "__main__":
     else:
         print("Invalid file name. Your first argument must be a `*.json` file name.")
         sys.exit()
+
+    low_severity_unreachable = os.getenv('LOW_SEVERITY_UNREACHABLE', False)
+    print(low_severity_unreachable)
 
     print("Starting conversion process from Semgrep JSON to GitLab Dependency JSON")
     data = {

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -2,6 +2,7 @@ import json
 import sys
 import os
 import getopt
+import logging
 from datetime import datetime
 from collections import defaultdict
 
@@ -211,13 +212,12 @@ def str_to_bool(value):
 
 if __name__ == "__main__":
 
+    logging.basicConfig(level=logging.INFO)
+    
     user_inputs = sys.argv[1:]
     # get option and value pair from getopt
     try:
         opts, args = getopt.getopt(user_inputs, "u", ["unreachable="])
-        #lets's check out how getopt parse the arguments
-        logging.debug(opts)
-        logging.debug(args)
     except getopt.GetoptError:
         logging.debug('pass the arguments like <Findings JSON file> -u <true|false> or <Findings JSON file> --unreachable <true|false>')
         sys.exit(2)

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import os
 from datetime import datetime
 from collections import defaultdict
 

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -223,6 +223,7 @@ if __name__ == "__main__":
         # The first non-option argument will be treated as the json_file
         if len(args) > 0:
             report_semgrep = args[0]
+            print(report_semgrep)
         else:
             raise ValueError("No JSON file provided.")
 
@@ -233,10 +234,14 @@ if __name__ == "__main__":
 
     # Parse options
     for opt, arg in opts:
+        print("+++")
+        print(opt)
         if opt in ('-h', '--help'):
             print('Usage: scaGitLabScript.py <json_file> [--lowering-unreachable true|false]')
             sys.exit()
         elif opt == '--lowering-unreachable':
+            print("***")
+            print(arg.lower())
             if arg.lower() == 'true':
                 lowering_unreachable = True
             elif arg.lower() == 'false':

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -214,7 +214,7 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=logging.INFO)
     
-   lowering_unreachable = False  # Default to False unless explicitly set
+    lowering_unreachable = False  # Default to False unless explicitly set
 
     try:
         # Define options: 'h' for help, 'l:' for the '--lowering-unreachable' which expects a value

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -217,7 +217,7 @@ if __name__ == "__main__":
     user_inputs = sys.argv[1:]
     # get option and value pair from getopt
     try:
-        opts, args = getopt.getopt(user_inputs, "lowering-unreachable")
+        opts, args = getopt.getopt(user_inputs, "lu", ["lowering-unreachable="])
     except getopt.GetoptError:
         logging.debug('pass the arguments like <Findings JSON file> --lowering-unreachable <true|false>')
         sys.exit(2)

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
 
         # The first non-option argument will be treated as the json_file
         if len(args) > 0:
-            json_file = args[0]
+            report_semgrep = args[0]
         else:
             raise ValueError("No JSON file provided.")
 

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -211,6 +211,10 @@ def to_hungarian_case(input_string):
 if __name__ == "__main__":
 
     logging.basicConfig(level=logging.INFO)
+    if len(sys.argv) == 1:
+        print('Usage: scaGitLabScript.py <json_file> [--lowering-unreachable true|false]')
+        sys.exit()
+    
     user_inputs = sys.argv[1:]
     lowering_unreachable = False  # Default to False unless explicitly set
 

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -245,9 +245,6 @@ if __name__ == "__main__":
                 print('Invalid value for --lowering-unreachable. Use true or false.')
                 sys.exit(2)
 
-            
-    print("lowering_unreachable")
-    print(lowering_unreachable)
     print("Starting conversion process from Semgrep JSON to GitLab Dependency JSON")
     data = {
         "version": "15.0.0",

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -217,17 +217,14 @@ if __name__ == "__main__":
     lowering_unreachable = False  # Default to False unless explicitly set
 
     try:
-        # Define options: 'h' for help, 'l:' for the '--lowering-unreachable' which expects a value
-        opts, args = getopt.getopt(user_inputs, "h", ["help", "lowering-unreachable="])
-        print("+++")
-        print(opts)
-        print(args)
-        # The first non-option argument will be treated as the json_file
-        if len(args) > 0:
-            report_semgrep = args[0]
-            print(report_semgrep)
+        # Define options: 'h' for help, '--lowering-unreachable' which expects a value
+        opts, args = getopt.getopt(user_inputs[1:], "h", ["lowering-unreachable=", "help"])
+        
+        if sys.argv[1].endswith('.json'):
+            report_semgrep = sys.argv[1]
         else:
-            raise ValueError("No JSON file provided.")
+            print("Invalid file name. Your first argument must be a `*.json` file name.")
+            sys.exit()
 
     except getopt.GetoptError as err:
         print(str(err))
@@ -236,15 +233,10 @@ if __name__ == "__main__":
 
     # Parse options
     for opt, arg in opts:
-        print("+++")
-        print(opt)
-        print(arg)
         if opt in ('-h', '--help'):
             print('Usage: scaGitLabScript.py <json_file> [--lowering-unreachable true|false]')
             sys.exit()
         elif opt == '--lowering-unreachable':
-            print("***")
-            print(arg.lower())
             if arg.lower() == 'true':
                 lowering_unreachable = True
             elif arg.lower() == 'false':

--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -213,12 +213,12 @@ def str_to_bool(value):
 if __name__ == "__main__":
 
     logging.basicConfig(level=logging.INFO)
-    
+    user_inputs = sys.argv[1:]
     lowering_unreachable = False  # Default to False unless explicitly set
 
     try:
         # Define options: 'h' for help, 'l:' for the '--lowering-unreachable' which expects a value
-        opts, args = getopt.getopt(argv, "h", ["help", "lowering-unreachable="])
+        opts, args = getopt.getopt(user_inputs, "h", ["help", "lowering-unreachable="])
 
         # The first non-option argument will be treated as the json_file
         if len(args) > 0:


### PR DESCRIPTION
It will lower the severity of unreachable findings.
It is configurable through an environment variable: `LOWER_SEVERITY_UNREACHABLE`, if set to `True` then it will decrease the severity of unreachable findings to Info level.
If the variable is not set or if it set to `False`, then it will keep the severity as it is coming from Semgrep.