### PR TITLE
Update python_client_semgrep_api.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ python3 utilities/api/python_client_semgrep_api.py
 
 The script does the following:
 * Get your current deployment (example 'acme')
-* Iterate through all the projects to get the findings
+* Iterate through all the projects to get the (by default) open findings
 * Dump a JSON report for each project.
-  
+
+**_NOTE:_** You can get fixed (ignored) findings by setting the status array to statuses = ["fixed"] (statuses = ["ignored"])
 **_NOTE:_** Take into account the `SEMGREP_APP_TOKEN` must have API permissions.
 **_NOTE:_** The variable `USE_PRIMARY_BRANCH_PARAM` could be set to True or False. True to get findings for the primary (main) branch.
 

--- a/utilities/api/python_client_semgrep_api.py
+++ b/utilities/api/python_client_semgrep_api.py
@@ -29,6 +29,7 @@ def retrieve_paginated_data(endpoint, kind, page_size, headers):
             sys.exit(f'Get failed: {r.text}')
         data = r.json()
         if not data.get(kind):
+            print(f"At page {page} there is no more data of {kind}")
             hasMore = False
         data_list.extend(data.get(kind))
     return json.dumps({ f"{kind}": data_list})
@@ -79,8 +80,9 @@ def get_findings_per_project(deployment_slug, project, primary_branch, headers):
     ## all_statutes = ["open", "fixing", "reviewing", "fixed", "ignored"]
     open_statuses = ["open", "fixing", "reviewing"]
     merged_findings = {"findings": []}
+    findings_url = f"{BASE_URL}/{deployment_slug}/findings?repos={project}&dedup=false"
     for status in open_statuses:
-        findings_url = f"{BASE_URL}/{deployment_slug}/findings?repos={project}&dedup=false&status={status}"
+        findings_url = f"{findings_url}&status={status}"
         if USE_PRIMARY_BRANCH_PARAM:
             findings_url = f"{findings_url}&ref={primary_branch}"
         project_findings = retrieve_paginated_data(findings_url, "findings", 3000, headers=headers)


### PR DESCRIPTION
Two changes:

1. Transform the primary branch from "refs/heads/xxxx" to "xxxx", as the first expression is not retrieving any information.
2. Filter by status. Now, it is easier to retrieve open findings (status = open, fixing and reviewing).