### PR TITLE
Update transform2.py

### DIFF
--- a/maven/transform2.py
+++ b/maven/transform2.py
@@ -47,6 +47,13 @@ def transform_lines_with_space(original):
             continue
         parts = line.split(':')
         if len(parts) > 2:
+            # Check if parts[2] matches the pattern: whitespace + bracket + (e|ev|.)
+            # Example, the line: com.fasterxml.jackson.core:jackson-databind:2.12.7.1 (..
+            # will be discarded
+            # before it was transformed to: com.fasterxml.jackson.core:jackson-databind:jar:2.12.7.1 (..:compile
+            # See: CSE-1676 for more details
+            if re.search(r'\s[\(](e|ev|\.)', parts[2]):
+                continue  # Discard this line
             parts.insert(2, 'jar')
             parts.append('compile')
             line = ':'.join(parts)


### PR DESCRIPTION
There are some lines that the transformation script did not skip.
Example:
```
com.fasterxml.jackson.core:jackson-annotations:2.10.1 (e..
com.fasterxml.jackson.core:jackson-databind:2.12.7.1 (..
```

I decided to leave the regex to skip evicted lines as it is:
`if re.search(r'(evi.+', line):`
It seems risky to reduce the regular expression even more.

Instead, I decided to check if the last part (after splitting the line) matches:

`whitespace + ( + (e|ev|.)`

Example 1, the line:
`com.fasterxml.jackson.core:jackson-annotations:2.10.1 (e..`
Will be ignored because the second part: `2.10.1 (e..` matches `whitespace + ( + e`

Example 2, the line:
`com.fasterxml.jackson.core:jackson-databind:2.12.7.1 (..`
Will be ignored because the second part: `2.12.7.1 (..` matches `whitespace + ( + .`