### PR TITLE
improve path and line to point to correct file

### DIFF
--- a/integrations/gitlab/scaGitLabScript.py
+++ b/integrations/gitlab/scaGitLabScript.py
@@ -28,9 +28,10 @@ def conversion_semgrep_to_gitlab(report_semgrep, data, lowering_unreachable):
                             "severity": get_severity(vuln, lowering_unreachable),
                             "solution": "Upgrade dependencies to fixed versions: "+get_solution(vuln), 
                             "location": {
-                                "file": vuln.get('extra').get('sca_info').get('dependency_match')['lockfile'],
-                                "start_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency').get('line_number'),
-                                "end_line": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency').get('line_number'),
+                                # It gets the file path. It can be source code for reachable findings or the lockfile (manifest file) for other cases.
+                                "file": vuln.get('path'),
+                                "start_line": vuln.get('start').get('line'),
+                                "end_line": vuln.get('end').get('line'),
                                 "dependency": {
                                     "package": {
                                         "name": vuln.get('extra').get('sca_info').get('dependency_match').get('found_dependency')['package']


### PR DESCRIPTION
Now, the finding in the GitLab report points to the source code in cases of reachable findings (before it pointed to the lockfile).

<img width="1183" alt="Screenshot 2025-04-24 at 15 18 08" src="https://github.com/user-attachments/assets/8be8f11f-5235-4644-bfcf-6b03bfc51abc" />
<img width="1166" alt="Screenshot 2025-04-24 at 15 18 35" src="https://github.com/user-attachments/assets/1ba7bda7-0dea-4c9a-8a66-cccf7e7aff4d" />
