### PR TITLE
Update transform2.py

### DIFF
--- a/maven/transform2.py
+++ b/maven/transform2.py
@@ -43,7 +43,8 @@ def transform_lines_with_space(original):
         # Skip "evicted" dependencies as they are superseded by a different version
         # This regex is short and simple because "evicted" is sometimes truncated
         # When revising, recommended to check behavior and performance with a regex tester
-        if re.search(r'\(evi.+', line):
+        # It will also skip lines ending with ... as they don't show a valid dependency
+        if re.search(r'\(evi.+', line) or line.endswith('...'):
             continue
         parts = line.split(':')
         if len(parts) > 2:


### PR DESCRIPTION
Even applying the statement:
sbt `"set asciiGraphWidth := 9999"` "dependencyTree::toFile maven_dep_tree.txt -f"
Some customer sees truncated lines like this:
`    +-com.fasterxml.jackson.core:jackson-databind:2.14...`

So, now it will skip lines ending with three dots (truncated lines) as they don't show a valid version for the dependency.