### PR TITLE
Update transform2.py

### DIFF
--- a/maven/transform2.py
+++ b/maven/transform2.py
@@ -16,7 +16,7 @@ actual_lines = result.stdout
 
 # Function to determine if a line should be skipped
 def should_be_skipped(line):
-    return re.search(r'\(evi.+', line) or line.endswith('...')
+    return re.search(r'\(e.*', line) or re.search(r'\.\.+$', line)
 
 # Function to extract and transform only the relevant lines
 def extract_and_transform_lines(actual):


### PR DESCRIPTION
We need to skip lines like these:
 ` | | | | | | | | | |   +-com.fasterxml.jackson.core:jackson-databind:2.4.3 (e..`
  `| | | | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.9.10.8 (ev..`
`  | | | | | | | | +-com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2..`
  
 These lines were not skipped before.

✅ This now skips:
Lines ending with `..`, `...`, or more dots.
Lines with any `(e...` pattern.