### PR TITLE
Update transform2.py

### DIFF
--- a/maven/transform2.py
+++ b/maven/transform2.py
@@ -2,20 +2,24 @@ import subprocess
 import re
 import sys
 
+# Check for correct usage and print usage instructions if needed
 if len(sys.argv) != 2:
     print("Usage: python transform2.py <path_to_maven_dep_tree.txt file>")
     sys.exit(1)
     
 file_path = sys.argv[1]
 
-# Run the sbt dependencyTree command and capture the output
+# Read file contents using subprocess (to allow for future flexibility, e.g., piping)
 result = subprocess.run(["cat", file_path], capture_output=True, text=True)
 
 # Assign the output to actual_lines
 actual_lines = result.stdout
 
 # Function to determine if a line should be skipped
+# Skips lines that are evicted (sometimes truncated) or end with ... (not a valid dependency)
 def should_be_skipped(line):
+    # This regex is short and simple because "evicted" is sometimes truncated
+    # When revising, recommended to check behavior and performance with a regex tester
     return re.search(r'\(e.*', line) or re.search(r'\.\.+$', line)
 
 # Function to extract and transform only the relevant lines
@@ -35,43 +39,45 @@ def extract_and_transform_lines(actual):
     
     return transformed_lines
 
-# Function to transform lines with correct spacing
 def transform_lines_with_space(original):
     lines = original.strip().split("\n")
     transformed_lines = []
+    root_seen = False
 
     for line in lines:
-        line = line.replace("[info]", "").replace("[S]", "").strip()
-        # Skip lines that contain only pipes and spaces or empty lines
-        if re.match('^[ |]+$', line) or line == "":
+        original_line = line  # for calculating indent
+        clean_line = line.replace("[info]", "").replace("[S]", "").strip()
+        if re.match(r'^[\|\+\-\s]+$', clean_line) or clean_line == "" or should_be_skipped(clean_line):
             continue
-        # Skip "evicted" dependencies as they are superseded by a different version
-        # This regex is short and simple because "evicted" is sometimes truncated
-        # When revising, recommended to check behavior and performance with a regex tester
-        # It will also skip lines ending with ... as they don't show a valid dependency, 
-        # for example: +-io.opentelemetry.semconv:opentelemetry-semconv-incubating:1...
-        if should_be_skipped(line):
-            continue
-        parts = line.split(':')
-        if len(parts) > 2:
-            # Check if parts[2] matches the pattern: whitespace + bracket + (e|ev|.)
-            # Example, the line: com.fasterxml.jackson.core:jackson-databind:2.12.7.1 (..
-            # will be discarded
-            # before it was transformed to: com.fasterxml.jackson.core:jackson-databind:jar:2.12.7.1 (..:compile
-            # See: CSE-1676 for more details
+
+        # Calculate indentation depth (each 2 spaces == 1 level)
+        indent_match = re.match(r'^([ |]+)\+-', line)
+        if indent_match:
+            indent_str = indent_match.group(1)
+            depth = indent_str.count('|') + indent_str.count('  ')
+        else:
+            depth = 0
+
+        # Clean the line from old tree characters
+        line_content = re.sub(r'^[\|\+\-\s]+', '', clean_line)
+
+        parts = line_content.split(':')
+        if len(parts) >= 3:
             if re.search(r'\s[\(](e|ev|\.)', parts[2]):
-                continue  # Discard this line
+                continue
             parts.insert(2, 'jar')
             parts.append('compile')
-            line = ':'.join(parts)
-        # These ensure that the spacing of the pipes and +- notations are correct/consistent
-        line = line.replace("+-", "+- ")
-        line = re.sub(r'\|\s+', "|  ", line)
-        # Add the line to the list if it's not empty
-        if line:
-            transformed_lines.append(line)
-    
+            formatted_line = ':'.join(parts)
+
+            if not root_seen:
+                transformed_lines.append(formatted_line)
+                root_seen = True
+            else:
+                prefix = "|  " * (depth - 1) + "+- " if depth > 0 else "+- "
+                transformed_lines.append(prefix + formatted_line)
+
     return "\n".join(transformed_lines)
+
 
 # Print the transformed output with correct spacing
 final_transformed_output = extract_and_transform_lines(actual_lines)


### PR DESCRIPTION
With this change, we maintain the relationship between direct and transitive dependencies.
Taking this file as input:
```
com.semgrep.dfapi:functional-test_2.12:4.21.4 [S]
  +-com.semgrep.dfapi:dfapi_main_2.12:4.21.4 [S]
    +-ch.qos.logback:logback-classic:1.4.14
    | +-ch.qos.logback:logback-core:1.4.14
    | +-org.slf4j:slf4j-api:2.0.7 (evicted by: 2.0.9)
    | +-org.slf4j:slf4j-api:2.0.9
    +-org.typelevel:cats-effect_2.12:2.5.4 [S]
      +-org.typelevel:cats-core_2.12:2.6.1 (evicted by: 2.9.0)
      +-org.typelevel:cats-core_2.12:2.9.0 [S]
        +-org.typelevel:cats-kernel_2.12:2.9.0 [S]
```

Before the change, it was transformed to:
```
com.semgrep.dfapi:functional-test_2.12:jar:4.21.4:compile
+- com.semgrep.dfapi:dfapi_main_2.12:jar:4.21.4:compile
+- ch.qos.logback:logback-classic:jar:1.4.14:compile
|  +- ch.qos.logback:logback-core:jar:1.4.14:compile
|  +- org.slf4j:slf4j-api:jar:2.0.9:compile
+- org.typelevel:cats-effect_2.12:jar:2.5.4:compile
+- org.typelevel:cats-core_2.12:jar:2.9.0:compile
+- org.typelevel:cats-kernel_2.12:jar:2.9.0:compile
```

After the change, it is transformed to:
```
com.semgrep.dfapi:functional-test_2.12:jar:4.21.4:compile
+- com.semgrep.dfapi:dfapi_main_2.12:jar:4.21.4:compile
|  +- ch.qos.logback:logback-classic:jar:1.4.14:compile
|  |  +- ch.qos.logback:logback-core:jar:1.4.14:compile
|  |  +- org.slf4j:slf4j-api:jar:2.0.9:compile
|  +- org.typelevel:cats-effect_2.12:jar:2.5.4:compile
|  |  +- org.typelevel:cats-core_2.12:jar:2.9.0:compile
|  |  |  +- org.typelevel:cats-kernel_2.12:jar:2.9.0:compile
```