### PR TITLE
Remove scan coverage section

### DIFF
--- a/utilities/reporting/report-generator-python/pdf/basic_pdf_generator.py
+++ b/utilities/reporting/report-generator-python/pdf/basic_pdf_generator.py
@@ -453,10 +453,16 @@ class BasicPdfGenerator:
         # Scan Coverage
         story.append(Paragraph('Scan Coverage', st['GreenSubTitle']))
         scan_data_row = [['SAST', 'Supply Chain', 'Secrets']]
+        secrets_done = any(p.scan_data.secrets_completed for p in projects)
+        secrets_para = Paragraph(
+            'Complete' if secrets_done else 'Missing',
+            ParagraphStyle('sm', textColor=HexColor('#28A745') if secrets_done else RED,
+                           fontName='Helvetica-Bold', fontSize=11)
+        )
         scan_status_row = [
             [Paragraph('Complete', ParagraphStyle('sc', textColor=HexColor('#28A745'), fontName='Helvetica-Bold', fontSize=11)),
              Paragraph('Complete', ParagraphStyle('sc2', textColor=HexColor('#28A745'), fontName='Helvetica-Bold', fontSize=11)),
-             Paragraph('Missing', ParagraphStyle('sm', textColor=RED, fontName='Helvetica-Bold', fontSize=11))],
+             secrets_para],
         ]
         scan_table = Table(
             [scan_data_row[0], scan_status_row[0]],

--- a/utilities/reporting/report-generator-python/pdf/basic_pdf_generator.py
+++ b/utilities/reporting/report-generator-python/pdf/basic_pdf_generator.py
@@ -448,36 +448,6 @@ class BasicPdfGenerator:
                                         ('BOTTOMPADDING', (0, 0), (-1, -1), 3)]))
             story.append(t)
 
-        story.append(Spacer(1, 12))
-
-        # Scan Coverage
-        story.append(Paragraph('Scan Coverage', st['GreenSubTitle']))
-        scan_data_row = [['SAST', 'Supply Chain', 'Secrets']]
-        secrets_done = any(p.scan_data.secrets_completed for p in projects)
-        secrets_para = Paragraph(
-            'Complete' if secrets_done else 'Missing',
-            ParagraphStyle('sm', textColor=HexColor('#28A745') if secrets_done else RED,
-                           fontName='Helvetica-Bold', fontSize=11)
-        )
-        scan_status_row = [
-            [Paragraph('Complete', ParagraphStyle('sc', textColor=HexColor('#28A745'), fontName='Helvetica-Bold', fontSize=11)),
-             Paragraph('Complete', ParagraphStyle('sc2', textColor=HexColor('#28A745'), fontName='Helvetica-Bold', fontSize=11)),
-             secrets_para],
-        ]
-        scan_table = Table(
-            [scan_data_row[0], scan_status_row[0]],
-            colWidths=[CONTENT_WIDTH / 3] * 3,
-            style=TableStyle([
-                ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
-                ('FONTSIZE', (0, 0), (-1, -1), 11),
-                ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
-                ('GRID', (0, 0), (-1, -1), 0.5, BORDER_GRAY),
-                ('TOPPADDING', (0, 0), (-1, -1), 8),
-                ('BOTTOMPADDING', (0, 0), (-1, -1), 8),
-            ])
-        )
-        story.append(scan_table)
-
         return story
 
     def _executive_summary_page(self, projects, config, open_findings, overall_level) -> list:

--- a/utilities/reporting/report-generator-python/services/semgrep_api_client.py
+++ b/utilities/reporting/report-generator-python/services/semgrep_api_client.py
@@ -209,7 +209,7 @@ class SemgrepApiClient:
                 scan_data=ScanMetadata(
                     sast_completed=True,
                     supply_chain_completed=True,
-                    secrets_completed=random.random() > 0.5,
+                    secrets_completed=False,
                     files_scanned=random.randint(50, 500),
                     scan_duration=random.randint(2 * 60000, 15 * 60000),
                     engine_version='1.45.0',
@@ -231,11 +231,15 @@ class SemgrepApiClient:
                         target_repo_name = p.get('name')
                         break
 
-            findings_to_process = [
-                f for f in findings_data['findings']
-                if target_repo_name and
-                   f.get('repository', {}).get('name', '').lower() == target_repo_name.lower()
-            ]
+            if target_repo_name:
+                findings_to_process = [
+                    f for f in findings_data['findings']
+                    if f.get('repository', {}).get('name', '').lower() == target_repo_name.lower()
+                ]
+            else:
+                print(f'Warning: Project ID {config_project_id} not found in org projects list. '
+                      f'Check that organizationName in your config matches the org that owns this project.')
+                findings_to_process = []
             print(f'Project {config_project_id} ({target_repo_name}): Found {len(findings_to_process)} findings')
 
         if target_repo_name:
@@ -266,6 +270,23 @@ class SemgrepApiClient:
             )
             project_findings.append(finding)
 
+        def _is_secrets_finding(raw: dict) -> bool:
+            product = (raw.get('product') or '').lower()
+            if product == 'secrets':
+                return True
+            issue_type = (raw.get('issue_type') or raw.get('type') or '').lower()
+            if issue_type == 'secrets':
+                return True
+            rule_name = (raw.get('rule', {}).get('name') or raw.get('check_id') or '').lower()
+            if rule_name.startswith('secrets.') or '.secrets.' in rule_name:
+                return True
+            categories = raw.get('rule', {}).get('categories') or raw.get('categories') or []
+            if any('secret' in str(c).lower() for c in categories):
+                return True
+            return False
+
+        secrets_completed = any(_is_secrets_finding(raw) for raw in findings_to_process)
+
         return SemgrepProject(
             name=project_name,
             repository=project_name,
@@ -277,7 +298,7 @@ class SemgrepApiClient:
             scan_data=ScanMetadata(
                 sast_completed=True,
                 supply_chain_completed=True,
-                secrets_completed=random.random() > 0.5,
+                secrets_completed=secrets_completed,
                 files_scanned=random.randint(50, 500),
                 scan_duration=random.randint(2 * 60000, 15 * 60000),
                 engine_version='1.45.0',

--- a/utilities/reporting/report-generator-python/services/semgrep_api_client.py
+++ b/utilities/reporting/report-generator-python/services/semgrep_api_client.py
@@ -207,8 +207,8 @@ class SemgrepApiClient:
                 last_scanned=datetime.now() - timedelta(hours=random.random() * 48),
                 findings=[],
                 scan_data=ScanMetadata(
-                    sast_completed=True,
-                    supply_chain_completed=True,
+                    sast_completed=False,
+                    supply_chain_completed=False,
                     secrets_completed=False,
                     files_scanned=random.randint(50, 500),
                     scan_duration=random.randint(2 * 60000, 15 * 60000),
@@ -270,23 +270,6 @@ class SemgrepApiClient:
             )
             project_findings.append(finding)
 
-        def _is_secrets_finding(raw: dict) -> bool:
-            product = (raw.get('product') or '').lower()
-            if product == 'secrets':
-                return True
-            issue_type = (raw.get('issue_type') or raw.get('type') or '').lower()
-            if issue_type == 'secrets':
-                return True
-            rule_name = (raw.get('rule', {}).get('name') or raw.get('check_id') or '').lower()
-            if rule_name.startswith('secrets.') or '.secrets.' in rule_name:
-                return True
-            categories = raw.get('rule', {}).get('categories') or raw.get('categories') or []
-            if any('secret' in str(c).lower() for c in categories):
-                return True
-            return False
-
-        secrets_completed = any(_is_secrets_finding(raw) for raw in findings_to_process)
-
         return SemgrepProject(
             name=project_name,
             repository=project_name,
@@ -296,8 +279,8 @@ class SemgrepApiClient:
             last_scanned=datetime.now() - timedelta(hours=random.random() * 48),
             findings=project_findings,
             scan_data=ScanMetadata(
-                sast_completed=True,
-                supply_chain_completed=True,
+                sast_completed=False,
+                supply_chain_completed=False,
                 secrets_completed=secrets_completed,
                 files_scanned=random.randint(50, 500),
                 scan_duration=random.randint(2 * 60000, 15 * 60000),
@@ -492,7 +475,7 @@ class SemgrepApiClient:
             scan_data=ScanMetadata(
                 sast_completed=True,
                 supply_chain_completed=True,
-                secrets_completed=random.random() > 0.5,
+                secrets_completed=True,
                 files_scanned=random.randint(50, 500),
                 scan_duration=random.randint(2 * 60000, 15 * 60000),
                 engine_version='1.45.0',


### PR DESCRIPTION
The code scan coverage section that reports "Complete" or "Missing" for each scan type is misleading.  There is currently no easy way to determine the last time a specific scan type ran and whether or not open findings from that scan are included in the report.  So, I have decided to remove that section.