### PR TITLE
Enhance github_recent_contributors.py for licensing reporting

### DIFF
--- a/utilities/contributors/README.md
+++ b/utilities/contributors/README.md
@@ -1,59 +1,281 @@
 # github_recent_contributors.py
-This script is meant to help estimate the number of contributors that are active within a Github organization over a period of time.
 
-The script does not use exactly the same logic as Semgrep in determining active contributors but should be helpful in determining a rough estimate.
+A comprehensive GitHub contributor analysis tool designed for licensing audits and usage reporting. This script provides detailed insights into contributor activity across GitHub organizations, helping you understand who has committed code, when, and where.
+
+## Features
+
+### Detailed Contributor Analysis
+- **Per-repository contributor breakdowns** - See who contributed to each repo
+- **Per-contributor activity metrics** - Track commits, date ranges, and repositories per contributor
+- **Org member vs external contributor distinction** - Identify who requires licenses
+- **Comprehensive JSON output** - Full data export for compliance and reporting
+- **Flexible repository filtering** - Analyze all repos or specific subsets
+
+### Output Includes
+- Which contributors worked on which repositories
+- Commit counts per contributor per repository
+- First and last commit dates for each contributor in each repository
+- Clear identification of org members requiring licenses
+- Summary statistics for quick overview
+- Top contributors ranked by commit count
+
+## Requirements
+
+- Python 3.x
+- `requests` library: `pip3 install requests`
+- GitHub Personal Access Token with appropriate permissions
+
+### GitHub Token Permissions
+
+Your Personal Access Token needs the following scopes:
+- `repo` (or `public_repo` for public repositories only)
+- `read:org`
+- `read:user`
+- `user:email` (optional, but recommended)
+
+## Installation
+
+1. Install the required Python library:
+   ```bash
+   pip3 install requests
+   ```
+
+2. Create a GitHub Personal Access Token at https://github.com/settings/tokens
+
+3. Export your token as an environment variable:
+   ```bash
+   export GITHUB_PERSONAL_ACCESS_TOKEN='your_token_here'
+   ```
 
 ## Usage
-You'll need to first export a [Github PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) into your environment for the script to use.
 
-Export your PAT as the variable `GITHUB_PERSONAL_ACCESS_TOKEN`.  
+### Analyze All Repositories
 
-Example: 
-```
-export GITHUB_PERSONAL_ACCESS_TOKEN=ghp_BunchOfSecretStuffGoesHere
+```bash
+python3 github_recent_contributors.py MyOrg 90 report.json
 ```
 
-The Token will need the following scopes:
-- repo
-- read:org
-- read:user
-- user:email
+This analyzes all repositories in the organization for the last 90 days.
 
-The script takes the following arguements:
-- The name of the github organization
-- The number of days to look over (we recommend 90 as a safe default)
-- An output filename to store the details from the execution
+### Analyze Specific Repositories
 
-After you have the PAT in your environment, run this script like this:
-```
-python3 github_recent_contributors.py r2c-cse 90 output.json
+```bash
+python3 github_recent_contributors.py MyOrg 90 report.json --repos repo1 repo2 repo3
 ```
 
-## Output
-Example console output:
+This analyzes only the specified repositories.
+
+### Command-Line Arguments
+
+- `org_name` - The name of the GitHub organization (required)
+- `number_of_days` - Number of days to look back for commits (required)
+- `output_filename` - Path to save the JSON report (required)
+- `--repos` - Space-separated list of repository names to analyze (optional)
+
+## Output Format
+
+### Console Output
+
+The script prints a detailed summary to the console:
+
 ```
-Total commit authors in the last 90 days: 33
-Total members in r2c-cse: 16
-Total unique contributors from r2c-cse in the last 90 days: 5
+============================================================
+LICENSING REPORT SUMMARY
+============================================================
+Organization: MyOrg
+Period: Last 90 days
+Repositories analyzed: 45
+
+============================================================
+CONTRIBUTOR COUNTS
+============================================================
+Total commit authors: 23
+  ├─ Org members who committed: 18
+  └─ External contributors: 5
+
+Total org members: 25
+  └─ Requiring licenses (committed): 18
+
+============================================================
+TOP 10 CONTRIBUTORS (by commit count)
+============================================================
+ 1. [✓ ORG] alice              - 245 commits across 12 repos
+ 2. [✓ ORG] bob                - 198 commits across 8 repos
+ 3. [  EXT] contractor1        - 156 commits across 3 repos
+ ...
 ```
 
-Example output file:
-```
+### JSON Output Structure
+
+The JSON file contains comprehensive data with the following structure:
+
+```json
 {
-    "organization": "r2c-cse",
-    "date": "2023-09-26",
-    "number_of_days_history": 90,
+  "report_metadata": {
+    "organization": "MyOrg",
+    "report_date": "2026-04-10",
+    "analysis_period_days": 90,
+    "date_range": {
+      "from": "2026-01-10",
+      "to": "2026-04-10"
+    }
+  },
+  "summary": {
+    "total_repositories_analyzed": 45,
+    "total_commit_authors": 23,
+    "total_org_members": 25,
+    "committing_org_members": 18,
+    "external_contributors": 5,
+    "total_commits": 1234
+  },
+  "licensing_counts": {
+    "org_members_requiring_licenses": ["alice", "bob", "charlie", ...],
+    "count": 18
+  },
+  "contributors_by_type": {
     "org_members": [
-        ...
+      {
+        "login": "alice",
+        "name": "Alice Smith",
+        "total_commits": 245,
+        "is_org_member": true,
+        "contributor_type": "org_member",
+        "repositories": [
+          {
+            "repository": "api-service",
+            "commit_count": 89,
+            "first_commit_date": "2026-01-15T10:23:45Z",
+            "last_commit_date": "2026-04-08T16:42:12Z"
+          }
+        ]
+      }
     ],
-    "commit_authors": [
-        ...
-    ],
-    "commiting_members": [
-        ...
-    ]
+    "external_contributors": [...]
+  },
+  "repository_details": [
+    {
+      "repository": "api-service",
+      "contributor_count": 8,
+      "total_commits": 342,
+      "contributors": [
+        {
+          "login": "alice",
+          "name": "Alice Smith",
+          "commit_count": 89,
+          "first_commit_date": "2026-01-15T10:23:45Z",
+          "last_commit_date": "2026-04-08T16:42:12Z"
+        }
+      ]
+    }
+  ],
+  "detailed_contributor_list": [
+    {
+      "login": "alice",
+      "name": "Alice Smith",
+      "total_commits": 245,
+      "is_org_member": true,
+      "contributor_type": "org_member",
+      "repositories": [...]
+    }
+  ]
 }
 ```
+
+#### Key Sections
+
+**report_metadata**: Report generation details
+- Organization name
+- Report generation date
+- Analysis period
+- Exact date range analyzed
+
+**summary**: Aggregate statistics
+- Total repositories analyzed
+- Total unique commit authors
+- Org member counts
+- External contributor counts
+- Total commits in period
+
+**licensing_counts**: License requirement data
+- List of org members who committed code
+- Count requiring licenses
+
+**contributors_by_type**: Detailed breakdowns
+- Org members with their activity
+- External contributors with their activity
+
+**repository_details**: Per-repository information
+- Repository name
+- Contributor count per repo
+- Total commits per repo
+- List of contributors with commit counts and date ranges
+
+**detailed_contributor_list**: Per-contributor summary
+- Login and name
+- Total commits across all repos
+- List of repositories they contributed to
+- Commit counts per repository
+- First and last commit dates per repository
+- Organization membership status
+
+## Use Cases
+
+### Licensing Audits
+Identify exactly which organization members have committed code and require licenses for tools like Semgrep.
+
+### Activity Tracking
+Understand contributor patterns, identify most active contributors, and track repository engagement.
+
+### External Contributor Management
+Identify and track external contributors (contractors, open-source contributors, etc.) separately from organization members.
+
+### Compliance Reporting
+Generate comprehensive reports for compliance, security, or management review with full commit history and date ranges.
+
+### Budget Planning
+Use contributor counts and activity levels to plan tool licensing budgets and resource allocation.
+
+## Security Notes
+
+- Keep your GitHub Personal Access Token secure
+- Never commit tokens to version control
+- Never expose tokens in client-side code or public repositories
+- Use environment variables for token storage
+- Rotate tokens regularly
+- Use the minimum required token permissions
+
+## Example Workflow
+
+```bash
+# Set up environment
+export GITHUB_PERSONAL_ACCESS_TOKEN='ghp_xxxxxxxxxxxx'
+
+# Run analysis for last quarter (90 days) on all repos
+python3 github_recent_contributors.py acme-corp 90 quarterly-report.json
+
+# Run analysis on specific security-critical repos
+python3 github_recent_contributors.py acme-corp 30 security-audit.json \
+  --repos auth-service payment-api user-management
+
+# View the JSON report
+cat quarterly-report.json | jq '.summary'
+```
+
+## Troubleshooting
+
+### "Error fetching repositories for organization"
+- Verify your token has `read:org` permission
+- Ensure the organization name is correct
+- Check that your token hasn't expired
+
+### "Please set your GITHUB_PERSONAL_ACCESS_TOKEN"
+- Make sure you've exported the environment variable
+- Verify the variable name is exactly `GITHUB_PERSONAL_ACCESS_TOKEN`
+
+### Empty or missing data
+- Check your token has `repo` or `public_repo` permission
+- Verify repositories have commits in the specified date range
+- Ensure the repository names are spelled correctly (when using --repos)
 
 # gitlab_contributor_count.py
 

--- a/utilities/contributors/github_recent_contributors.py
+++ b/utilities/contributors/github_recent_contributors.py
@@ -52,10 +52,47 @@ Note:
 - Keep your tokens secure and never expose them in client-side code or public repositories.
 """
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 import os
 from datetime import datetime, timedelta, timezone, UTC
 import argparse
 import json
+
+
+# Per-request timeout (seconds). Without this a stalled connection can hang forever.
+REQUEST_TIMEOUT = 30
+
+
+def make_session():
+    """Build a requests.Session with retries and backoff.
+
+    Across a large org (thousands of repos) the GitHub API will occasionally
+    drop a connection ("Connection reset by peer") or return a transient
+    5xx / rate-limit (429) response. A bare request would abort the entire run
+    on the first such blip; retries with exponential backoff make the run
+    resilient and respect GitHub's Retry-After header for rate limiting.
+    """
+    retry = Retry(
+        total=5,
+        connect=5,
+        read=5,
+        status=5,
+        backoff_factor=2,  # 0s, 2s, 4s, 8s, 16s between attempts
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["GET"],
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+# Module-level session reused for every request (also reuses TCP connections).
+session = make_session()
 
 
 def get_repos(org_name, headers):
@@ -64,10 +101,11 @@ def get_repos(org_name, headers):
     page = 1  # Start from page 1
 
     while True:
-        response = requests.get(
+        response = session.get(
             f'https://api.github.com/orgs/{org_name}/repos',
             headers=headers,
-            params={'per_page': 100, 'page': page}  # Fetch 100 repos per page
+            params={'per_page': 100, 'page': page},  # Fetch 100 repos per page
+            timeout=REQUEST_TIMEOUT
         )
 
         if response.status_code != 200:
@@ -96,9 +134,11 @@ def get_organization_members(org_name, headers):
     members = []
     page = 1
     while True:
-        response = requests.get(
-            f'https://api.github.com/orgs/{org_name}/members?page={page}',
-            headers=headers
+        response = session.get(
+            f'https://api.github.com/orgs/{org_name}/members',
+            headers=headers,
+            params={'per_page': 100, 'page': page},
+            timeout=REQUEST_TIMEOUT
         )
         if response.status_code != 200:
             break
@@ -141,16 +181,39 @@ def get_contributors(org_name, number_of_days, headers):
                 #print(f"skipping: {repo_name}")
                 continue
 
-        # Fetch commits for each repository in the given date range
-        response = requests.get(
-            f'https://api.github.com/repos/{owner}/{repo_name}/commits',
-            params={'since': since_date, 'until': until_date},
-            headers=headers
-        )
+        # Fetch commits for each repository in the given date range.
+        # The commits endpoint is paginated (max 100 per page); without
+        # following pagination, active repos would silently undercount
+        # commits and miss contributors. Isolate failures per repo so a
+        # single bad/unreachable repo doesn't abort the whole run.
+        commits = []
+        empty_repo = False
+        try:
+            page = 1
+            while True:
+                response = session.get(
+                    f'https://api.github.com/repos/{owner}/{repo_name}/commits',
+                    params={'since': since_date, 'until': until_date,
+                            'per_page': 100, 'page': page},
+                    headers=headers,
+                    timeout=REQUEST_TIMEOUT
+                )
+                page_commits = response.json()
+                if not isinstance(page_commits, list):
+                    # GitHub returns 409 with a dict body for empty repos.
+                    empty_repo = response.status_code == 409
+                    break
+                if not page_commits:
+                    break
+                commits.extend(page_commits)
+                if len(page_commits) < 100:
+                    break
+                page += 1
+        except requests.exceptions.RequestException as e:
+            print(f"Warning: failed to fetch commits for {repo_name}: {e}. Skipping repo.")
+            continue
 
-        commits = response.json()
-
-        if isinstance(commits, list):
+        if commits:
             # Initialize repo tracking
             repo_contributors = {}
 
@@ -208,7 +271,7 @@ def get_contributors(org_name, number_of_days, headers):
                         'first_commit_date': details['first_commit_date'],
                         'last_commit_date': details['last_commit_date']
                     })
-        else:
+        elif empty_repo:
             print(f"Repo: {repo_name} is empty.")
 
     return unique_contributors, unique_authors, repo_details, contributor_details

--- a/utilities/contributors/github_recent_contributors.py
+++ b/utilities/contributors/github_recent_contributors.py
@@ -1,14 +1,34 @@
 """
-GitHub Recent Contributors Script
----------------------------------
-This script fetches and prints the unique contributors from the last 30 days
-across all the repositories in a specified GitHub organization.
+GitHub Recent Contributors Script - Enhanced for Licensing Reporting
+---------------------------------------------------------------------
+This script provides detailed contributor analysis for GitHub organizations,
+specifically designed for licensing audits and usage reporting.
+
+Features:
+- Detailed per-repository contributor breakdowns
+- Per-contributor activity metrics (commit counts, date ranges, repositories)
+- Distinction between org members and external contributors
+- Comprehensive JSON output for licensing compliance
+- Support for analyzing all repos or specific subsets
+
+Output includes:
+- Which contributors worked on which repositories
+- How many commits each contributor made
+- First and last commit dates for each contributor per repository
+- Clear identification of org members requiring licenses
+- Summary statistics for quick overview
 
 Directions:
-1. Save this script as `github_recent_contributors.py` in a directory of your choice.
-2. Open a terminal and navigate to the directory where this script is saved.
-3. Install the required Python library: `pip3 install requests`
-4. Run the script with: `usage: python3 github_recent_contributors.py ORG_NAME NUMBER_OF_DAYS OUTPUT_FILENAME [--repos REPO1 REPO2 ...]`
+1. Install the required Python library: `pip3 install requests`
+2. Export your GitHub Personal Access Token:
+   export GITHUB_PERSONAL_ACCESS_TOKEN='your_token_here'
+3. Run the script:
+
+   # Analyze all repos for 90 days
+   python3 github_recent_contributors.py MyOrg 90 report.json
+
+   # Analyze specific repos only
+   python3 github_recent_contributors.py MyOrg 90 report.json --repos repo1 repo2 repo3
 
 Requirements:
 - Python 3.x
@@ -20,10 +40,13 @@ GitHub Permissions Needed:
 - read:user
 - user:email (optional, but recommended)
 
-Before Running:
-- Export your Github Personal Access Token to the environment variable 'GITHUB_PERSONAL_ACCESS_TOKEN'
-- Pass in your Github Org Name and the Number of Days over which you'd like to list contributors
-- Ensure your token has the necessary scopes and permissions.
+JSON Output Structure:
+- report_metadata: Report date, organization, analysis period
+- summary: Aggregate counts and totals
+- licensing_counts: List of org members requiring licenses
+- contributors_by_type: Detailed breakdown of org members vs external contributors
+- repository_details: Per-repository contributor lists with commit counts
+- detailed_contributor_list: Per-contributor summary across all repositories
 
 Note:
 - Keep your tokens secure and never expose them in client-side code or public repositories.
@@ -48,7 +71,15 @@ def get_repos(org_name, headers):
         )
 
         if response.status_code != 200:
-            raise ValueError(f"Error fetching repositories for organization {org_name}. Status code: {response.status_code}")
+            error_msg = f"Error fetching repositories for organization {org_name}. Status code: {response.status_code}"
+            try:
+                error_details = response.json()
+                error_msg += f"\nGitHub API response: {error_details.get('message', 'No message')}"
+                if 'documentation_url' in error_details:
+                    error_msg += f"\nDocs: {error_details['documentation_url']}"
+            except:
+                error_msg += f"\nResponse: {response.text}"
+            raise ValueError(error_msg)
 
         data = response.json()
         
@@ -83,6 +114,10 @@ def get_contributors(org_name, number_of_days, headers):
     unique_contributors = set()
     unique_authors = set()
 
+    # Enhanced tracking structures
+    repo_details = {}  # Per-repository contributor details
+    contributor_details = {}  # Per-contributor details across repos
+
     if not repo_list:
         print("No repo names provided. Will count contributors to all repos in the org [" + org_name + "]")
 
@@ -105,25 +140,78 @@ def get_contributors(org_name, number_of_days, headers):
             else:
                 #print(f"skipping: {repo_name}")
                 continue
-        
+
         # Fetch commits for each repository in the given date range
         response = requests.get(
             f'https://api.github.com/repos/{owner}/{repo_name}/commits',
             params={'since': since_date, 'until': until_date},
             headers=headers
         )
-        
+
         commits = response.json()
 
         if isinstance(commits, list):
+            # Initialize repo tracking
+            repo_contributors = {}
+
             for commit in commits:
-                unique_contributors.add(commit['commit']['author']['name'])
-                if commit['author']:
-                    unique_authors.add(commit['author']['login'])
+                author_name = commit['commit']['author']['name']
+                author_login = commit['author']['login'] if commit['author'] else None
+                commit_date = commit['commit']['author']['date']
+
+                unique_contributors.add(author_name)
+
+                if author_login:
+                    unique_authors.add(author_login)
+
+                    # Track per-repository contributors
+                    if author_login not in repo_contributors:
+                        repo_contributors[author_login] = {
+                            'login': author_login,
+                            'name': author_name,
+                            'commit_count': 0,
+                            'first_commit_date': commit_date,
+                            'last_commit_date': commit_date
+                        }
+                    repo_contributors[author_login]['commit_count'] += 1
+
+                    # Update date range
+                    if commit_date < repo_contributors[author_login]['first_commit_date']:
+                        repo_contributors[author_login]['first_commit_date'] = commit_date
+                    if commit_date > repo_contributors[author_login]['last_commit_date']:
+                        repo_contributors[author_login]['last_commit_date'] = commit_date
+
+                    # Track per-contributor activity across repos
+                    if author_login not in contributor_details:
+                        contributor_details[author_login] = {
+                            'login': author_login,
+                            'name': author_name,
+                            'total_commits': 0,
+                            'repositories': []
+                        }
+                    contributor_details[author_login]['total_commits'] += 1
+
+            # Store repo details if there were commits
+            if repo_contributors:
+                repo_details[repo_name] = {
+                    'repository': repo_name,
+                    'contributor_count': len(repo_contributors),
+                    'total_commits': sum(c['commit_count'] for c in repo_contributors.values()),
+                    'contributors': list(repo_contributors.values())
+                }
+
+                # Update contributor details with repo information
+                for login, details in repo_contributors.items():
+                    contributor_details[login]['repositories'].append({
+                        'repository': repo_name,
+                        'commit_count': details['commit_count'],
+                        'first_commit_date': details['first_commit_date'],
+                        'last_commit_date': details['last_commit_date']
+                    })
         else:
-            print(f"Repo: {repo_name} is empty.") 
-        
-    return unique_contributors, unique_authors
+            print(f"Repo: {repo_name} is empty.")
+
+    return unique_contributors, unique_authors, repo_details, contributor_details
 
 def report_contributors(org_name, number_of_days, output_file):
     # init github auth
@@ -133,25 +221,93 @@ def report_contributors(org_name, number_of_days, output_file):
     headers = {'Authorization': f'token {token}'}
 
     org_members = get_organization_members(org_name, headers)
-    unique_contributors, unique_authors = get_contributors(org_name, number_of_days, headers)
-    
+    unique_contributors, unique_authors, repo_details, contributor_details = get_contributors(org_name, number_of_days, headers)
+
+    # Calculate member status for each contributor
+    committing_members = unique_authors & org_members
+    external_contributors = unique_authors - org_members
+
+    # Enhance contributor details with org membership info
+    for login, details in contributor_details.items():
+        details['is_org_member'] = login in org_members
+        details['contributor_type'] = 'org_member' if login in org_members else 'external'
+        # Sort repositories by commit count (descending)
+        details['repositories'].sort(key=lambda x: x['commit_count'], reverse=True)
+
     if output_file:
         output_data = {
-            "organization": org_name,
-            "date": datetime.today().date().strftime('%Y-%m-%d'),
-            "number_of_days_history": number_of_days,
-            "org_members": list(org_members),
-            "commit_authors": list(unique_authors),
-            "commiting_members": list(unique_authors & org_members)
+            "report_metadata": {
+                "organization": org_name,
+                "report_date": datetime.today().date().strftime('%Y-%m-%d'),
+                "analysis_period_days": number_of_days,
+                "date_range": {
+                    "from": (datetime.now(timezone.utc) - timedelta(days=number_of_days)).strftime('%Y-%m-%d'),
+                    "to": datetime.now(timezone.utc).strftime('%Y-%m-%d')
+                }
+            },
+            "summary": {
+                "total_repositories_analyzed": len(repo_details),
+                "total_commit_authors": len(unique_authors),
+                "total_org_members": len(org_members),
+                "committing_org_members": len(committing_members),
+                "external_contributors": len(external_contributors),
+                "total_commits": sum(r['total_commits'] for r in repo_details.values())
+            },
+            "licensing_counts": {
+                "org_members_requiring_licenses": list(committing_members),
+                "count": len(committing_members)
+            },
+            "contributors_by_type": {
+                "org_members": [
+                    contributor_details[login] for login in committing_members
+                ],
+                "external_contributors": [
+                    contributor_details[login] for login in external_contributors
+                ]
+            },
+            "repository_details": list(repo_details.values()),
+            "detailed_contributor_list": sorted(
+                contributor_details.values(),
+                key=lambda x: x['total_commits'],
+                reverse=True
+            )
         }
 
         with open(output_file, 'w') as file:
-            json.dump(output_data, file)
+            json.dump(output_data, file, indent=2)
 
-    # Print unique contributors and their total count        
-    print(f"Total commit authors in the last {number_of_days} days:", len(unique_authors))
-    print(f"Total members in {org_name}:", len(org_members))
-    print(f"Total unique contributors from {org_name} in the last {number_of_days} days:", len(unique_authors & org_members))
+        print(f"\n✓ Detailed report saved to: {output_file}")
+
+    # Print summary statistics
+    print(f"\n{'='*60}")
+    print(f"LICENSING REPORT SUMMARY")
+    print(f"{'='*60}")
+    print(f"Organization: {org_name}")
+    print(f"Period: Last {number_of_days} days")
+    print(f"Repositories analyzed: {len(repo_details)}")
+    print(f"\n{'='*60}")
+    print(f"CONTRIBUTOR COUNTS")
+    print(f"{'='*60}")
+    print(f"Total commit authors: {len(unique_authors)}")
+    print(f"  ├─ Org members who committed: {len(committing_members)}")
+    print(f"  └─ External contributors: {len(external_contributors)}")
+    print(f"\nTotal org members: {len(org_members)}")
+    print(f"  └─ Requiring licenses (committed): {len(committing_members)}")
+
+    # Show top contributors
+    print(f"\n{'='*60}")
+    print(f"TOP 10 CONTRIBUTORS (by commit count)")
+    print(f"{'='*60}")
+    sorted_contributors = sorted(
+        contributor_details.values(),
+        key=lambda x: x['total_commits'],
+        reverse=True
+    )
+    for i, contrib in enumerate(sorted_contributors[:10], 1):
+        member_badge = "✓ ORG" if contrib['is_org_member'] else "  EXT"
+        print(f"{i:2}. [{member_badge}] {contrib['login']:20} - {contrib['total_commits']:4} commits across {len(contrib['repositories'])} repos")
+
+    print(f"\n{'='*60}")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
## Summary

Enhances `utilities/contributors/github_recent_contributors.py` to support detailed licensing/usage reporting for GitHub organizations.

### Changes
- **Per-repository breakdowns** — tracks which contributors worked on which repos, with commit counts and first/last commit dates.
- **Per-contributor metrics** — total commits and the list of repositories each contributor touched.
- **Org-member vs external classification** — flags which contributors are org members requiring licenses.
- **Richer structured JSON output** — `report_metadata`, `summary`, `licensing_counts`, `contributors_by_type`, `repository_details`, and `detailed_contributor_list` (pretty-printed).
- **Improved API error handling** — surfaces GitHub's error `message` and docs URL on failures.
- **Formatted console summary** — licensing report with counts and a top-10 contributors table.
- Updated `README.md` to document the new output structure and usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)